### PR TITLE
Schema 2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,10 +15,10 @@ Encoding: UTF-8
 Depends: 
     svglite
 Imports: 
-    bdsreader (>= 0.6.0),
+    bdsreader (>= 0.9.1),
     chartbox (>= 1.6.0),
-    chartcatalog (>= 1.8.0),
-    chartplotter (>= 0.25.1),
+    chartcatalog (>= 1.9.0),
+    chartplotter (>= 0.27.0),
     dplyr,
     curl,
     grid (>= 4.1.0),
@@ -29,7 +29,7 @@ Imports:
     rlang,
     utils
 Suggests: 
-    jamesdemodata (>= 0.5.0),
+    jamesdemodata (>= 0.7.0),
     testthat
 Remotes: 
     growthcharts/bdsreader,

--- a/R/calculate_dscore.R
+++ b/R/calculate_dscore.R
@@ -15,11 +15,11 @@
 #' @keywords server
 #' @examples
 #' fn <- system.file("testdata", "Laura_S_dev.json", package = "james")
-#' d <- calculate_dscore(txt = fn)
+#' d <- calculate_dscore(txt = fn, version = 1)
 #' @export
 calculate_dscore <- function(txt = "",
                              loc = "",
-                             version = 1L,
+                             version = 2L,
                              output = c("table", "last_visit", "last_dscore")) {
   output <- match.arg(output)
   tgt <- get_tgt(txt, loc, version = version)

--- a/R/calculate_dscore.R
+++ b/R/calculate_dscore.R
@@ -15,11 +15,11 @@
 #' @keywords server
 #' @examples
 #' fn <- system.file("testdata", "Laura_S_dev.json", package = "james")
-#' d <- calculate_dscore(txt = fn, format = 1)
+#' d <- calculate_dscore(txt = fn)
 #' @export
 calculate_dscore <- function(txt = "",
                              loc = "",
-                             format = 2L,
+                             format = "1.0",
                              output = c("table", "last_visit", "last_dscore")) {
   output <- match.arg(output)
   tgt <- get_tgt(txt, loc, format = format)

--- a/R/calculate_dscore.R
+++ b/R/calculate_dscore.R
@@ -9,6 +9,7 @@
 #' the number of visits. If `output` equals `"last_visit"` the
 #' function returns only the last row. If `output` equals
 #' `"last_dscore"` the function returns only the D-score from the last row.
+#' @inheritParams bdsreader::read_bds
 #' @return A table, row or scalar.
 #' @author Stef van Buuren 2020
 #' @keywords server
@@ -18,10 +19,10 @@
 #' @export
 calculate_dscore <- function(txt = "",
                              loc = "",
-                             schema = "bds_schema_str.json",
+                             version = 1L,
                              output = c("table", "last_visit", "last_dscore")) {
   output <- match.arg(output)
-  tgt <- get_tgt(txt, loc, schema = schema)
+  tgt <- get_tgt(txt, loc, version = version)
 
   if (!hasName(attributes(tgt), "person")) {
     message("Cannot calculate D-score")

--- a/R/calculate_dscore.R
+++ b/R/calculate_dscore.R
@@ -15,14 +15,14 @@
 #' @keywords server
 #' @examples
 #' fn <- system.file("testdata", "Laura_S_dev.json", package = "james")
-#' d <- calculate_dscore(txt = fn, version = 1)
+#' d <- calculate_dscore(txt = fn, format = 1)
 #' @export
 calculate_dscore <- function(txt = "",
                              loc = "",
-                             version = 2L,
+                             format = 2L,
                              output = c("table", "last_visit", "last_dscore")) {
   output <- match.arg(output)
-  tgt <- get_tgt(txt, loc, version = version)
+  tgt <- get_tgt(txt, loc, format = format)
 
   if (!hasName(attributes(tgt), "person")) {
     message("Cannot calculate D-score")

--- a/R/convert_bds_ind.R
+++ b/R/convert_bds_ind.R
@@ -9,12 +9,12 @@
 #' @author Stef van Buuren 2021
 #' @examples
 #' fn <- system.file("testdata", "client3.json", package = "james")
-#' p <- convert_bds_ind(fn)
+#' p <- convert_bds_ind(fn, version = 1)
 #' @keywords server
 #' @export
-convert_bds_ind <- function(txt = "", ...) {
+convert_bds_ind <- function(txt = "", version = 2L, ...) {
   .Deprecated("fetch_loc",
     msg = "convert_bds_ind() is deprecated. Please use fetch_loc() instead."
   )
-  fetch_loc(txt = txt, ...)
+  fetch_loc(txt = txt, version = version, ...)
 }

--- a/R/convert_bds_ind.R
+++ b/R/convert_bds_ind.R
@@ -9,12 +9,12 @@
 #' @author Stef van Buuren 2021
 #' @examples
 #' fn <- system.file("testdata", "client3.json", package = "james")
-#' p <- convert_bds_ind(fn, version = 1)
+#' p <- convert_bds_ind(fn, format = 1)
 #' @keywords server
 #' @export
-convert_bds_ind <- function(txt = "", version = 2L, ...) {
+convert_bds_ind <- function(txt = "", format = 2L, ...) {
   .Deprecated("fetch_loc",
     msg = "convert_bds_ind() is deprecated. Please use fetch_loc() instead."
   )
-  fetch_loc(txt = txt, version = version, ...)
+  fetch_loc(txt = txt, format = format, ...)
 }

--- a/R/convert_bds_ind.R
+++ b/R/convert_bds_ind.R
@@ -9,10 +9,10 @@
 #' @author Stef van Buuren 2021
 #' @examples
 #' fn <- system.file("testdata", "client3.json", package = "james")
-#' p <- convert_bds_ind(fn, format = 1)
+#' p <- convert_bds_ind(fn)
 #' @keywords server
 #' @export
-convert_bds_ind <- function(txt = "", format = 2L, ...) {
+convert_bds_ind <- function(txt = "", format = "1.0", ...) {
   .Deprecated("fetch_loc",
     msg = "convert_bds_ind() is deprecated. Please use fetch_loc() instead."
   )

--- a/R/convert_tgt_chartadvice.R
+++ b/R/convert_tgt_chartadvice.R
@@ -40,7 +40,7 @@
 #' @keywords server
 #' @export
 convert_tgt_chartadvice <- function(txt = "", loc = "",
-                                    schema = "bds_schema_str.json",
+                                    version = 1L,
                                     chartcode = "",
                                     selector = c("data", "chartcode"),
                                     ind_loc = "") {
@@ -54,7 +54,7 @@ convert_tgt_chartadvice <- function(txt = "", loc = "",
   if (!is.empty(ind_loc)) loc <- ind_loc
 
   selector <- match.arg(selector)
-  tgt <- get_tgt(txt = txt, loc = loc, schema = schema)
+  tgt <- get_tgt(txt = txt, loc = loc, version = version)
   chartcode <- switch(selector,
     "data" = select_chart(target = tgt)$chartcode,
     "chartcode" = chartcode

--- a/R/convert_tgt_chartadvice.R
+++ b/R/convert_tgt_chartadvice.R
@@ -40,7 +40,7 @@
 #' @keywords server
 #' @export
 convert_tgt_chartadvice <- function(txt = "", loc = "",
-                                    version = 1L,
+                                    version = 2L,
                                     chartcode = "",
                                     selector = c("data", "chartcode"),
                                     ind_loc = "") {

--- a/R/convert_tgt_chartadvice.R
+++ b/R/convert_tgt_chartadvice.R
@@ -40,7 +40,7 @@
 #' @keywords server
 #' @export
 convert_tgt_chartadvice <- function(txt = "", loc = "",
-                                    format = 2L,
+                                    format = "1.0",
                                     chartcode = "",
                                     selector = c("data", "chartcode"),
                                     ind_loc = "") {

--- a/R/convert_tgt_chartadvice.R
+++ b/R/convert_tgt_chartadvice.R
@@ -40,7 +40,7 @@
 #' @keywords server
 #' @export
 convert_tgt_chartadvice <- function(txt = "", loc = "",
-                                    version = 2L,
+                                    format = 2L,
                                     chartcode = "",
                                     selector = c("data", "chartcode"),
                                     ind_loc = "") {
@@ -54,7 +54,7 @@ convert_tgt_chartadvice <- function(txt = "", loc = "",
   if (!is.empty(ind_loc)) loc <- ind_loc
 
   selector <- match.arg(selector)
-  tgt <- get_tgt(txt = txt, loc = loc, version = version)
+  tgt <- get_tgt(txt = txt, loc = loc, format = format)
   chartcode <- switch(selector,
     "data" = select_chart(target = tgt)$chartcode,
     "chartcode" = chartcode

--- a/R/custom_list.R
+++ b/R/custom_list.R
@@ -18,10 +18,10 @@
 #' identical(list1, list2)
 #' }
 #' @export
-custom_list <- function(txt = "", loc = "", version = 2L) {
-  site <- request_site(txt, loc, version = version)
+custom_list <- function(txt = "", loc = "", format = 2L) {
+  site <- request_site(txt, loc, format = format)
 
-  tgt <- get_tgt(txt, loc, version = version)
+  tgt <- get_tgt(txt, loc, format = format)
 
   res <- screen_curves_ind(tgt)
 

--- a/R/custom_list.R
+++ b/R/custom_list.R
@@ -1,6 +1,7 @@
 #' Provides a Screen growth curves according to JGZ guidelines
 #'
 #' @inheritParams request_site
+#' @inheritParams bdsreader::read_bds
 #' @return A table with screening results
 #' @return A list with custom parts
 #' @examples
@@ -17,10 +18,10 @@
 #' identical(list1, list2)
 #' }
 #' @export
-custom_list <- function(txt = "", loc = "", schema = "bds_schema_str.json") {
-  site <- request_site(txt, loc, schema = schema)
+custom_list <- function(txt = "", loc = "", version = 1L) {
+  site <- request_site(txt, loc, version = version)
 
-  tgt <- get_tgt(txt, loc, schema = schema)
+  tgt <- get_tgt(txt, loc, version = version)
 
   res <- screen_curves_ind(tgt)
 

--- a/R/custom_list.R
+++ b/R/custom_list.R
@@ -18,7 +18,7 @@
 #' identical(list1, list2)
 #' }
 #' @export
-custom_list <- function(txt = "", loc = "", version = 1L) {
+custom_list <- function(txt = "", loc = "", version = 2L) {
   site <- request_site(txt, loc, version = version)
 
   tgt <- get_tgt(txt, loc, version = version)

--- a/R/custom_list.R
+++ b/R/custom_list.R
@@ -18,7 +18,7 @@
 #' identical(list1, list2)
 #' }
 #' @export
-custom_list <- function(txt = "", loc = "", format = 2L) {
+custom_list <- function(txt = "", loc = "", format = "1.0") {
   site <- request_site(txt, loc, format = format)
 
   tgt <- get_tgt(txt, loc, format = format)

--- a/R/draw_chart.R
+++ b/R/draw_chart.R
@@ -40,11 +40,11 @@
 #' @keywords server
 #' @examples
 #' fn <- system.file("testdata", "client3.json", package = "james")
-#' g <- draw_chart(txt = fn, format = 1)
+#' g <- draw_chart(txt = fn)
 #' @export
 draw_chart <- function(txt = "",
                        loc = "",
-                       format = 2L,
+                       format = "1.0",
                        chartcode = "",
                        selector = c("data", "derive", "chartcode"),
                        chartgrp = NULL,

--- a/R/draw_chart.R
+++ b/R/draw_chart.R
@@ -40,11 +40,11 @@
 #' @keywords server
 #' @examples
 #' fn <- system.file("testdata", "client3.json", package = "james")
-#' g <- draw_chart(txt = fn)
+#' g <- draw_chart(txt = fn, version = 1)
 #' @export
 draw_chart <- function(txt = "",
                        loc = "",
-                       version = 1L,
+                       version = 2L,
                        chartcode = "",
                        selector = c("data", "derive", "chartcode"),
                        chartgrp = NULL,

--- a/R/draw_chart.R
+++ b/R/draw_chart.R
@@ -40,11 +40,11 @@
 #' @keywords server
 #' @examples
 #' fn <- system.file("testdata", "client3.json", package = "james")
-#' g <- draw_chart(txt = fn, version = 1)
+#' g <- draw_chart(txt = fn, format = 1)
 #' @export
 draw_chart <- function(txt = "",
                        loc = "",
-                       version = 2L,
+                       format = 2L,
                        chartcode = "",
                        selector = c("data", "derive", "chartcode"),
                        chartgrp = NULL,
@@ -91,7 +91,7 @@ draw_chart <- function(txt = "",
     )
   )
 
-  tgt <- get_tgt(txt, loc, version = version)
+  tgt <- get_tgt(txt, loc, format = format)
 
   # if we have no tgt, prioritise chartcode over derive
   # except when chartcode is empty

--- a/R/draw_chart.R
+++ b/R/draw_chart.R
@@ -4,6 +4,7 @@
 #' @inheritParams request_site
 #' @inheritParams select_chart
 #' @inheritParams chartplotter::process_chart
+#' @inheritParams bdsreader::read_bds
 #' @param dnr Donor data, Prediction horizon: `"0-2"`, `"2-4"`
 #' or `"4-18"`. May also be `"smocc"`, `"lollypop"`,
 #' `"terneuzen"` or `"pops"`.
@@ -43,7 +44,7 @@
 #' @export
 draw_chart <- function(txt = "",
                        loc = "",
-                       schema = "bds_schema_str.json",
+                       version = 1L,
                        chartcode = "",
                        selector = c("data", "derive", "chartcode"),
                        chartgrp = NULL,
@@ -65,7 +66,8 @@ draw_chart <- function(txt = "",
                        show_future = FALSE,
                        draw_grob = TRUE,
                        bds_data = "",
-                       ind_loc = "") {
+                       ind_loc = "",
+                       ...) {
   if (!missing(bds_data)) {
     warning("Argument bds_data is deprecated; please use txt instead.",
       call. = FALSE
@@ -89,7 +91,7 @@ draw_chart <- function(txt = "",
     )
   )
 
-  tgt <- get_tgt(txt, loc, schema = schema)
+  tgt <- get_tgt(txt, loc, version = version)
 
   # if we have no tgt, prioritise chartcode over derive
   # except when chartcode is empty

--- a/R/draw_chart_bds.R
+++ b/R/draw_chart_bds.R
@@ -15,12 +15,14 @@
 #'   "bsmodel"` for setting the broken stick model, or `call =
 #'   as.call(...)` for setting proper reference standards.
 #' @inheritParams chartplotter::process_chart
+#' @inheritParams bdsreader::set_schema
 #' @examples
 #' fn <- system.file("testdata", "client3.json", package = "james")
-#' g <- draw_chart_bds(txt = fn)
+#' g <- draw_chart_bds(txt = fn, version = 1)
 #' @keywords server
 #' @export
-draw_chart_bds <- function(txt = "", chartcode = "",
+draw_chart_bds <- function(txt = "", version = 2L,
+                           chartcode = "",
                            curve_interpolation = TRUE,
                            selector = "chartcode", ...) {
 
@@ -30,7 +32,7 @@ draw_chart_bds <- function(txt = "", chartcode = "",
   )
 
   draw_chart(
-    txt = txt, chartcode = chartcode,
+    txt = txt, version = version, chartcode = chartcode,
     curve_interpolation = curve_interpolation,
     selector = selector
   )

--- a/R/draw_chart_bds.R
+++ b/R/draw_chart_bds.R
@@ -18,10 +18,10 @@
 #' @inheritParams bdsreader::set_schema
 #' @examples
 #' fn <- system.file("testdata", "client3.json", package = "james")
-#' g <- draw_chart_bds(txt = fn, format = 1)
+#' g <- draw_chart_bds(txt = fn)
 #' @keywords server
 #' @export
-draw_chart_bds <- function(txt = "", format = 2L,
+draw_chart_bds <- function(txt = "", format = "1.0",
                            chartcode = "",
                            curve_interpolation = TRUE,
                            selector = "chartcode", ...) {

--- a/R/draw_chart_bds.R
+++ b/R/draw_chart_bds.R
@@ -18,10 +18,10 @@
 #' @inheritParams bdsreader::set_schema
 #' @examples
 #' fn <- system.file("testdata", "client3.json", package = "james")
-#' g <- draw_chart_bds(txt = fn, version = 1)
+#' g <- draw_chart_bds(txt = fn, format = 1)
 #' @keywords server
 #' @export
-draw_chart_bds <- function(txt = "", version = 2L,
+draw_chart_bds <- function(txt = "", format = 2L,
                            chartcode = "",
                            curve_interpolation = TRUE,
                            selector = "chartcode", ...) {
@@ -32,7 +32,7 @@ draw_chart_bds <- function(txt = "", version = 2L,
   )
 
   draw_chart(
-    txt = txt, version = version, chartcode = chartcode,
+    txt = txt, format = format, chartcode = chartcode,
     curve_interpolation = curve_interpolation,
     selector = selector
   )

--- a/R/fetch_loc.R
+++ b/R/fetch_loc.R
@@ -13,10 +13,10 @@
 #'          [jsonlite::fromJSON()]
 #' @examples
 #' fn <- system.file("testdata", "client3.json", package = "james")
-#' p <- fetch_loc(fn, format = 1)
+#' p <- fetch_loc(fn)
 #' @keywords server
 #' @export
 fetch_loc <- function(txt = "",
-                      format = 2L) {
+                      format = "1.0") {
   read_bds(txt = txt, format = format)
 }

--- a/R/fetch_loc.R
+++ b/R/fetch_loc.R
@@ -13,10 +13,10 @@
 #'          [jsonlite::fromJSON()]
 #' @examples
 #' fn <- system.file("testdata", "client3.json", package = "james")
-#' p <- fetch_loc(fn)
+#' p <- fetch_loc(fn, version = 1)
 #' @keywords server
 #' @export
 fetch_loc <- function(txt = "",
-                      version = 1L) {
+                      version = 2L) {
   read_bds(txt = txt, version = version)
 }

--- a/R/fetch_loc.R
+++ b/R/fetch_loc.R
@@ -6,12 +6,7 @@
 #' The function is useful for caching input data over multiple requests to
 #' `OpenCPU`. The cached data feed into other JAMES functions by means
 #' of the `"loc"` argument. The server wipes the cached data after 24 hours.
-#'
-#' @param txt A JSON string, URL or file
-#' @param schema The name of one the the built-in schema's.
-#' The default (`NULL`) loads `"bds_schema_str.json"`. See
-#' <https://github.com/growthcharts/bdsreader/tree/master/inst/json>
-#' for available schema's.
+#' @inheritParams bdsreader::read_bds
 #' @return A tibble with a person attribute
 #' @author Stef van Buuren 2021
 #' @seealso [bdsreader::read_bds()]
@@ -22,6 +17,6 @@
 #' @keywords server
 #' @export
 fetch_loc <- function(txt = "",
-                      schema = "bds_schema_str.json") {
-  read_bds(txt = txt, schema = schema)
+                      version = 1L) {
+  read_bds(txt = txt, version = version)
 }

--- a/R/fetch_loc.R
+++ b/R/fetch_loc.R
@@ -13,10 +13,10 @@
 #'          [jsonlite::fromJSON()]
 #' @examples
 #' fn <- system.file("testdata", "client3.json", package = "james")
-#' p <- fetch_loc(fn, version = 1)
+#' p <- fetch_loc(fn, format = 1)
 #' @keywords server
 #' @export
 fetch_loc <- function(txt = "",
-                      version = 2L) {
-  read_bds(txt = txt, version = version)
+                      format = 2L) {
+  read_bds(txt = txt, format = format)
 }

--- a/R/get.R
+++ b/R/get.R
@@ -10,8 +10,8 @@ get_host <- function() {
 }
 
 # returns url of uploaded data
-get_loc <- function(txt, host, version) {
-  resp <- upload_txt(txt, host = host, version = version)
+get_loc <- function(txt, host, format) {
+  resp <- upload_txt(txt, host = host, format = format)
   if (status_code(resp) != 201L) {
     message_for_status(resp,
       task = paste0(

--- a/R/get.R
+++ b/R/get.R
@@ -10,8 +10,8 @@ get_host <- function() {
 }
 
 # returns url of uploaded data
-get_loc <- function(txt, host, schema) {
-  resp <- upload_txt(txt, host = host, schema = schema)
+get_loc <- function(txt, host, version) {
+  resp <- upload_txt(txt, host = host, version = version)
   if (status_code(resp) != 201L) {
     message_for_status(resp,
       task = paste0(
@@ -25,7 +25,7 @@ get_loc <- function(txt, host, schema) {
 }
 
 # returns targetl or NULL
-get_tgt <- function(txt = "", loc = "", schema = "bds_schema_str.json") {
+get_tgt <- function(txt = "", loc = "", ...) {
 
   # no ind
   if (is.empty(txt) && is.empty(loc)) {
@@ -34,7 +34,7 @@ get_tgt <- function(txt = "", loc = "", schema = "bds_schema_str.json") {
 
   # create ind on-the-fly
   if (!is.empty(txt)) {
-    return(read_bds(txt, schema = schema))
+    return(read_bds(txt, ...))
   }
 
   # download ind

--- a/R/request_site.R
+++ b/R/request_site.R
@@ -67,7 +67,7 @@
 #' }
 #' @export
 request_site <- function(txt = "", loc = "",
-                         format = 2L,
+                         format = "1.0",
                          upload = TRUE, host = NULL) {
   txt <- txt[1L]
   loc <- loc[1L]

--- a/R/request_site.R
+++ b/R/request_site.R
@@ -67,7 +67,7 @@
 #' }
 #' @export
 request_site <- function(txt = "", loc = "",
-                         version = 1L,
+                         version = 2L,
                          upload = TRUE, host = NULL) {
   txt <- txt[1L]
   loc <- loc[1L]

--- a/R/request_site.R
+++ b/R/request_site.R
@@ -9,14 +9,13 @@
 #' and are converted to JSON according to `schema`.
 #' @param loc Alternative to `txt`. Location where input data is uploaded
 #' and converted to internal server format.
-#' @param schema Optional. A JSON string, URL or file that selects the JSON validation
-#' schema. Only used if the `txt` argument is specified.
 #' @param upload Logical. If `TRUE` then `request_site()` will upload
 #' the data in `txt` and return a site address with the `?loc=` query appended.
 #' Setting (`FALSE`) just appends `?txt=` to the site url, thus
 #' deferring validation and conversion to internal representation to the site.
 #' @param host URL of the JAMES server. By default, host is the currently
 #' running server that processes the request.
+#' @inheritParams bdsreader::read_bds
 #' @return URL composed of JAMES server, possibly appended by query string starting
 #' with `?txt=` or `?loc=`.
 #' @seealso [jamesclient::upload_txt()], [jamesclient::get_url()]
@@ -68,7 +67,7 @@
 #' }
 #' @export
 request_site <- function(txt = "", loc = "",
-                         schema = "bds_schema_str.json",
+                         version = 1L,
                          upload = TRUE, host = NULL) {
   txt <- txt[1L]
   loc <- loc[1L]
@@ -119,7 +118,7 @@ request_site <- function(txt = "", loc = "",
 
   # # return ?loc=, possibly after upload of txt
   if (!is.empty(txt) && upload) {
-    loc <- get_loc(txt, host, schema)
+    loc <- get_loc(txt, host, version = version)
   }
 
   ifelse(loc == "", site, paste0(site, "?loc=", loc))

--- a/R/request_site.R
+++ b/R/request_site.R
@@ -67,7 +67,7 @@
 #' }
 #' @export
 request_site <- function(txt = "", loc = "",
-                         version = 2L,
+                         format = 2L,
                          upload = TRUE, host = NULL) {
   txt <- txt[1L]
   loc <- loc[1L]
@@ -118,7 +118,7 @@ request_site <- function(txt = "", loc = "",
 
   # # return ?loc=, possibly after upload of txt
   if (!is.empty(txt) && upload) {
-    loc <- get_loc(txt, host, version = version)
+    loc <- get_loc(txt, host, format = format)
   }
 
   ifelse(loc == "", site, paste0(site, "?loc=", loc))

--- a/R/screen_curves.R
+++ b/R/screen_curves.R
@@ -2,6 +2,7 @@
 #'
 #' @name screen_curves-deprecated
 #' @inheritParams request_site
+#' @inheritParams bdsreader::read_bds
 #' @param location Legacy for `loc`
 #' @param legacy Logical indicating whether legacy should be done.
 #' @return A JSON string containing a table with screening results
@@ -24,8 +25,8 @@
 #' # # upload & screen
 #' # screen_curves(fn)
 #' @export
-screen_curves <- function(txt = "", loc = "", location = "",
-                          schema = "bds_schema_str.json", legacy = TRUE) {
+screen_curves <- function(txt = "", loc = "", location = "", version = 1L,
+                          legacy = TRUE) {
   .Deprecated("screen_growth",
     msg = "screen_curves() is deprecated. Please use screen_growth() or custom_list() instead."
   )
@@ -34,6 +35,6 @@ screen_curves <- function(txt = "", loc = "", location = "",
   if (legacy) {
     toJSON(custom_list(txt = txt, loc = loc))
   } else {
-    toJSON(screen_curves_ind(get_tgt(txt, loc, schema = schema)))
+    toJSON(screen_curves_ind(get_tgt(txt, loc, version = version)))
   }
 }

--- a/R/screen_curves.R
+++ b/R/screen_curves.R
@@ -25,7 +25,7 @@
 #' # # upload & screen
 #' # screen_curves(fn)
 #' @export
-screen_curves <- function(txt = "", loc = "", location = "", version = 1L,
+screen_curves <- function(txt = "", loc = "", location = "", version = 2L,
                           legacy = TRUE) {
   .Deprecated("screen_growth",
     msg = "screen_curves() is deprecated. Please use screen_growth() or custom_list() instead."

--- a/R/screen_curves.R
+++ b/R/screen_curves.R
@@ -25,7 +25,7 @@
 #' # # upload & screen
 #' # screen_curves(fn)
 #' @export
-screen_curves <- function(txt = "", loc = "", location = "", format = 2L,
+screen_curves <- function(txt = "", loc = "", location = "", format = "1.0",
                           legacy = TRUE) {
   .Deprecated("screen_growth",
     msg = "screen_curves() is deprecated. Please use screen_growth() or custom_list() instead."

--- a/R/screen_curves.R
+++ b/R/screen_curves.R
@@ -25,7 +25,7 @@
 #' # # upload & screen
 #' # screen_curves(fn)
 #' @export
-screen_curves <- function(txt = "", loc = "", location = "", version = 2L,
+screen_curves <- function(txt = "", loc = "", location = "", format = 2L,
                           legacy = TRUE) {
   .Deprecated("screen_growth",
     msg = "screen_curves() is deprecated. Please use screen_growth() or custom_list() instead."
@@ -35,6 +35,6 @@ screen_curves <- function(txt = "", loc = "", location = "", version = 2L,
   if (legacy) {
     toJSON(custom_list(txt = txt, loc = loc))
   } else {
-    toJSON(screen_curves_ind(get_tgt(txt, loc, version = version)))
+    toJSON(screen_curves_ind(get_tgt(txt, loc, format = format)))
   }
 }

--- a/R/screen_growth.R
+++ b/R/screen_growth.R
@@ -1,6 +1,7 @@
 #' Screen growth curves according to JGZ guidelines
 #'
 #' @inheritParams request_site
+#' @inheritParams bdsreader::read_bds
 #' @note `screen_growth` superseeds `screen_curves` and will
 #' only return results from growth screening.
 #' @examples
@@ -18,6 +19,6 @@
 #' screen_growth(fn)
 #' }
 #' @export
-screen_growth <- function(txt = "", loc = "", schema = "bds_schema_str.json") {
-  screen_curves_ind(get_tgt(txt, loc, schema = schema))
+screen_growth <- function(txt = "", loc = "", version = 1L) {
+  screen_curves_ind(get_tgt(txt, loc, version = version))
 }

--- a/R/screen_growth.R
+++ b/R/screen_growth.R
@@ -19,6 +19,6 @@
 #' screen_growth(fn)
 #' }
 #' @export
-screen_growth <- function(txt = "", loc = "", version = 1L) {
+screen_growth <- function(txt = "", loc = "", version = 2L) {
   screen_curves_ind(get_tgt(txt, loc, version = version))
 }

--- a/R/screen_growth.R
+++ b/R/screen_growth.R
@@ -19,6 +19,6 @@
 #' screen_growth(fn)
 #' }
 #' @export
-screen_growth <- function(txt = "", loc = "", format = 2L) {
+screen_growth <- function(txt = "", loc = "", format = "1.0") {
   screen_curves_ind(get_tgt(txt, loc, format = format))
 }

--- a/R/screen_growth.R
+++ b/R/screen_growth.R
@@ -19,6 +19,6 @@
 #' screen_growth(fn)
 #' }
 #' @export
-screen_growth <- function(txt = "", loc = "", version = 2L) {
-  screen_curves_ind(get_tgt(txt, loc, version = version))
+screen_growth <- function(txt = "", loc = "", format = 2L) {
+  screen_curves_ind(get_tgt(txt, loc, format = format))
 }

--- a/inst/www/index.html
+++ b/inst/www/index.html
@@ -5,15 +5,15 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="shortcut icon" href="#" />
-  <link rel="stylesheet" href="css/bootstrap.min.css">
-  <link rel="stylesheet" href="css/ion.rangeSlider.min.css">
-  <link rel="stylesheet" href="main.css">
-  <script type="text/javascript" src="js/jquery-3.5.1.min.js"></script>
-  <script type="text/javascript" src="js/popper.min.js"></script>
-  <script type="text/javascript" src="js/bootstrap.min.js"></script>
-  <script type="text/javascript" src="js/ion.rangeSlider.min.js"></script>
-  <script type="text/javascript" src="opencpu-0.5-james-0.1.js"></script>
-  <script type="text/javascript" src="update.js"></script>
+  <link rel="stylesheet" href="/ocpu/lib/james/www/css/bootstrap.min.css">
+  <link rel="stylesheet" href="/ocpu/lib/james/www/css/ion.rangeSlider.min.css">
+  <link rel="stylesheet" href="/ocpu/lib/james/www/main.css">
+  <script type="text/javascript" src="/ocpu/lib/james/www/js/jquery-3.5.1.min.js"></script>
+  <script type="text/javascript" src="/ocpu/lib/james/www/js/popper.min.js"></script>
+  <script type="text/javascript" src="/ocpu/lib/james/www/js/bootstrap.min.js"></script>
+  <script type="text/javascript" src="/ocpu/lib/james/www/js/ion.rangeSlider.min.js"></script>
+  <script type="text/javascript" src="/ocpu/lib/james/www/opencpu-0.5-james-0.1.js"></script>
+  <script type="text/javascript" src="/ocpu/lib/james/www/update.js"></script>
 </head>
 
 <body>
@@ -242,6 +242,6 @@
       </div>
     </div>
   </div> <!-- end container-fluid -->
-  <script type="text/javascript" src="start.js"></script>
+  <script type="text/javascript" src="/ocpu/lib/james/www/start.js"></script>
 </body>
 </html>

--- a/inst/www/start.js
+++ b/inst/www/start.js
@@ -9,6 +9,8 @@ var user_loc = urlParams.get('loc');
 if (urlParams.has('ind')) user_loc = urlParams.get('ind');
 const user_chartcode = urlParams.get('chartcode');
 
+ocpu.seturl("/ocpu/library/james/R"); //hardcode path
+
 
 // internal constants
 const slider_values = {

--- a/man/calculate_dscore.Rd
+++ b/man/calculate_dscore.Rd
@@ -7,7 +7,7 @@
 calculate_dscore(
   txt = "",
   loc = "",
-  version = 2L,
+  format = 2L,
   output = c("table", "last_visit", "last_dscore")
 )
 }
@@ -20,8 +20,8 @@ and are converted to JSON according to \code{schema}.}
 \item{loc}{Alternative to \code{txt}. Location where input data is uploaded
 and converted to internal server format.}
 
-\item{version}{Integer. JSON schema version number. There are currently two
-schemas supported, versions \code{1} and \code{2}.}
+\item{format}{Integer. JSON schema format number. There are currently two
+schemas supported, formats \code{1} and \code{2}.}
 
 \item{output}{A string, either \code{"table"}, \code{"last_visit"} or
 '\code{"last_dscore"} specifying the result. The default \code{"table"}
@@ -39,7 +39,7 @@ The function \code{draw_chart()} plots individual data on the growth chart.
 }
 \examples{
 fn <- system.file("testdata", "Laura_S_dev.json", package = "james")
-d <- calculate_dscore(txt = fn, version = 1)
+d <- calculate_dscore(txt = fn, format = 1)
 }
 \author{
 Stef van Buuren 2020

--- a/man/calculate_dscore.Rd
+++ b/man/calculate_dscore.Rd
@@ -7,7 +7,7 @@
 calculate_dscore(
   txt = "",
   loc = "",
-  version = 1L,
+  version = 2L,
   output = c("table", "last_visit", "last_dscore")
 )
 }
@@ -39,7 +39,7 @@ The function \code{draw_chart()} plots individual data on the growth chart.
 }
 \examples{
 fn <- system.file("testdata", "Laura_S_dev.json", package = "james")
-d <- calculate_dscore(txt = fn)
+d <- calculate_dscore(txt = fn, version = 1)
 }
 \author{
 Stef van Buuren 2020

--- a/man/calculate_dscore.Rd
+++ b/man/calculate_dscore.Rd
@@ -7,7 +7,7 @@
 calculate_dscore(
   txt = "",
   loc = "",
-  schema = "bds_schema_str.json",
+  version = 1L,
   output = c("table", "last_visit", "last_dscore")
 )
 }
@@ -20,8 +20,8 @@ and are converted to JSON according to \code{schema}.}
 \item{loc}{Alternative to \code{txt}. Location where input data is uploaded
 and converted to internal server format.}
 
-\item{schema}{Optional. A JSON string, URL or file that selects the JSON validation
-schema. Only used if the \code{txt} argument is specified.}
+\item{version}{Integer. JSON schema version number. There are currently two
+schemas supported, versions \code{1} and \code{2}.}
 
 \item{output}{A string, either \code{"table"}, \code{"last_visit"} or
 '\code{"last_dscore"} specifying the result. The default \code{"table"}

--- a/man/calculate_dscore.Rd
+++ b/man/calculate_dscore.Rd
@@ -7,7 +7,7 @@
 calculate_dscore(
   txt = "",
   loc = "",
-  format = 2L,
+  format = "1.0",
   output = c("table", "last_visit", "last_dscore")
 )
 }
@@ -20,8 +20,8 @@ and are converted to JSON according to \code{schema}.}
 \item{loc}{Alternative to \code{txt}. Location where input data is uploaded
 and converted to internal server format.}
 
-\item{format}{Integer. JSON schema format number. There are currently two
-schemas supported, formats \code{1} and \code{2}.}
+\item{format}{String. JSON data schema version number. There are currently
+three schemas supported: \code{1.0}, \code{1.1} and \code{2.0}.}
 
 \item{output}{A string, either \code{"table"}, \code{"last_visit"} or
 '\code{"last_dscore"} specifying the result. The default \code{"table"}
@@ -39,7 +39,7 @@ The function \code{draw_chart()} plots individual data on the growth chart.
 }
 \examples{
 fn <- system.file("testdata", "Laura_S_dev.json", package = "james")
-d <- calculate_dscore(txt = fn, format = 1)
+d <- calculate_dscore(txt = fn)
 }
 \author{
 Stef van Buuren 2020

--- a/man/convert_bds_ind-deprecated.Rd
+++ b/man/convert_bds_ind-deprecated.Rd
@@ -5,13 +5,13 @@
 \alias{convert_bds_ind}
 \title{Convert json BSD data for single individual to class individual}
 \usage{
-convert_bds_ind(txt = "", version = 2L, ...)
+convert_bds_ind(txt = "", format = 2L, ...)
 }
 \arguments{
 \item{txt}{A JSON string, URL or file}
 
-\item{version}{Integer. JSON schema version number. There are currently two
-schemas supported, versions \code{1} and \code{2}.}
+\item{format}{Integer. JSON schema format number. There are currently two
+schemas supported, formats \code{1} and \code{2}.}
 
 \item{...}{Passed down to \code{\link[jsonlite:fromJSON]{jsonlite::fromJSON()}}}
 }
@@ -27,7 +27,7 @@ Deprecated. Use \code{\link[=fetch_loc]{fetch_loc()}} instead.
 }
 \examples{
 fn <- system.file("testdata", "client3.json", package = "james")
-p <- convert_bds_ind(fn, version = 1)
+p <- convert_bds_ind(fn, format = 1)
 }
 \author{
 Stef van Buuren 2021

--- a/man/convert_bds_ind-deprecated.Rd
+++ b/man/convert_bds_ind-deprecated.Rd
@@ -10,7 +10,7 @@ convert_bds_ind(txt = "", ...)
 \arguments{
 \item{txt}{A JSON string, URL or file}
 
-\item{...}{Pass down to \code{\link[jsonlite:fromJSON]{jsonlite::fromJSON()}}}
+\item{...}{Passed down to \code{\link[jsonlite:fromJSON]{jsonlite::fromJSON()}}}
 }
 \value{
 A tibble with a person attribute.

--- a/man/convert_bds_ind-deprecated.Rd
+++ b/man/convert_bds_ind-deprecated.Rd
@@ -5,13 +5,13 @@
 \alias{convert_bds_ind}
 \title{Convert json BSD data for single individual to class individual}
 \usage{
-convert_bds_ind(txt = "", format = 2L, ...)
+convert_bds_ind(txt = "", format = "1.0", ...)
 }
 \arguments{
 \item{txt}{A JSON string, URL or file}
 
-\item{format}{Integer. JSON schema format number. There are currently two
-schemas supported, formats \code{1} and \code{2}.}
+\item{format}{String. JSON data schema version number. There are currently
+three schemas supported: \code{1.0}, \code{1.1} and \code{2.0}.}
 
 \item{...}{Passed down to \code{\link[jsonlite:fromJSON]{jsonlite::fromJSON()}}}
 }
@@ -27,7 +27,7 @@ Deprecated. Use \code{\link[=fetch_loc]{fetch_loc()}} instead.
 }
 \examples{
 fn <- system.file("testdata", "client3.json", package = "james")
-p <- convert_bds_ind(fn, format = 1)
+p <- convert_bds_ind(fn)
 }
 \author{
 Stef van Buuren 2021

--- a/man/convert_bds_ind-deprecated.Rd
+++ b/man/convert_bds_ind-deprecated.Rd
@@ -5,10 +5,13 @@
 \alias{convert_bds_ind}
 \title{Convert json BSD data for single individual to class individual}
 \usage{
-convert_bds_ind(txt = "", ...)
+convert_bds_ind(txt = "", version = 2L, ...)
 }
 \arguments{
 \item{txt}{A JSON string, URL or file}
+
+\item{version}{Integer. JSON schema version number. There are currently two
+schemas supported, versions \code{1} and \code{2}.}
 
 \item{...}{Passed down to \code{\link[jsonlite:fromJSON]{jsonlite::fromJSON()}}}
 }
@@ -24,7 +27,7 @@ Deprecated. Use \code{\link[=fetch_loc]{fetch_loc()}} instead.
 }
 \examples{
 fn <- system.file("testdata", "client3.json", package = "james")
-p <- convert_bds_ind(fn)
+p <- convert_bds_ind(fn, version = 1)
 }
 \author{
 Stef van Buuren 2021

--- a/man/convert_tgt_chartadvice.Rd
+++ b/man/convert_tgt_chartadvice.Rd
@@ -7,7 +7,7 @@
 convert_tgt_chartadvice(
   txt = "",
   loc = "",
-  schema = "bds_schema_str.json",
+  version = 1L,
   chartcode = "",
   selector = c("data", "chartcode"),
   ind_loc = ""
@@ -22,8 +22,8 @@ and are converted to JSON according to \code{schema}.}
 \item{loc}{Alternative to \code{txt}. Location where input data is uploaded
 and converted to internal server format.}
 
-\item{schema}{Optional. A JSON string, URL or file that selects the JSON validation
-schema. Only used if the \code{txt} argument is specified.}
+\item{version}{Integer. JSON schema version number. There are currently two
+schemas supported, versions \code{1} and \code{2}.}
 
 \item{chartcode}{Optional. The code of the requested growth chart.}
 

--- a/man/convert_tgt_chartadvice.Rd
+++ b/man/convert_tgt_chartadvice.Rd
@@ -7,7 +7,7 @@
 convert_tgt_chartadvice(
   txt = "",
   loc = "",
-  format = 2L,
+  format = "1.0",
   chartcode = "",
   selector = c("data", "chartcode"),
   ind_loc = ""
@@ -22,8 +22,8 @@ and are converted to JSON according to \code{schema}.}
 \item{loc}{Alternative to \code{txt}. Location where input data is uploaded
 and converted to internal server format.}
 
-\item{format}{Integer. JSON schema format number. There are currently two
-schemas supported, formats \code{1} and \code{2}.}
+\item{format}{String. JSON data schema version number. There are currently
+three schemas supported: \code{1.0}, \code{1.1} and \code{2.0}.}
 
 \item{chartcode}{Optional. The code of the requested growth chart.}
 

--- a/man/convert_tgt_chartadvice.Rd
+++ b/man/convert_tgt_chartadvice.Rd
@@ -7,7 +7,7 @@
 convert_tgt_chartadvice(
   txt = "",
   loc = "",
-  version = 1L,
+  version = 2L,
   chartcode = "",
   selector = c("data", "chartcode"),
   ind_loc = ""

--- a/man/convert_tgt_chartadvice.Rd
+++ b/man/convert_tgt_chartadvice.Rd
@@ -7,7 +7,7 @@
 convert_tgt_chartadvice(
   txt = "",
   loc = "",
-  version = 2L,
+  format = 2L,
   chartcode = "",
   selector = c("data", "chartcode"),
   ind_loc = ""
@@ -22,8 +22,8 @@ and are converted to JSON according to \code{schema}.}
 \item{loc}{Alternative to \code{txt}. Location where input data is uploaded
 and converted to internal server format.}
 
-\item{version}{Integer. JSON schema version number. There are currently two
-schemas supported, versions \code{1} and \code{2}.}
+\item{format}{Integer. JSON schema format number. There are currently two
+schemas supported, formats \code{1} and \code{2}.}
 
 \item{chartcode}{Optional. The code of the requested growth chart.}
 

--- a/man/custom_list.Rd
+++ b/man/custom_list.Rd
@@ -4,7 +4,7 @@
 \alias{custom_list}
 \title{Provides a Screen growth curves according to JGZ guidelines}
 \usage{
-custom_list(txt = "", loc = "", format = 2L)
+custom_list(txt = "", loc = "", format = "1.0")
 }
 \arguments{
 \item{txt}{A JSON string, URL or file with the data in JSON
@@ -15,8 +15,8 @@ and are converted to JSON according to \code{schema}.}
 \item{loc}{Alternative to \code{txt}. Location where input data is uploaded
 and converted to internal server format.}
 
-\item{format}{Integer. JSON schema format number. There are currently two
-schemas supported, formats \code{1} and \code{2}.}
+\item{format}{String. JSON data schema version number. There are currently
+three schemas supported: \code{1.0}, \code{1.1} and \code{2.0}.}
 }
 \value{
 A table with screening results

--- a/man/custom_list.Rd
+++ b/man/custom_list.Rd
@@ -4,7 +4,7 @@
 \alias{custom_list}
 \title{Provides a Screen growth curves according to JGZ guidelines}
 \usage{
-custom_list(txt = "", loc = "", version = 2L)
+custom_list(txt = "", loc = "", format = 2L)
 }
 \arguments{
 \item{txt}{A JSON string, URL or file with the data in JSON
@@ -15,8 +15,8 @@ and are converted to JSON according to \code{schema}.}
 \item{loc}{Alternative to \code{txt}. Location where input data is uploaded
 and converted to internal server format.}
 
-\item{version}{Integer. JSON schema version number. There are currently two
-schemas supported, versions \code{1} and \code{2}.}
+\item{format}{Integer. JSON schema format number. There are currently two
+schemas supported, formats \code{1} and \code{2}.}
 }
 \value{
 A table with screening results

--- a/man/custom_list.Rd
+++ b/man/custom_list.Rd
@@ -4,7 +4,7 @@
 \alias{custom_list}
 \title{Provides a Screen growth curves according to JGZ guidelines}
 \usage{
-custom_list(txt = "", loc = "", schema = "bds_schema_str.json")
+custom_list(txt = "", loc = "", version = 1L)
 }
 \arguments{
 \item{txt}{A JSON string, URL or file with the data in JSON
@@ -15,8 +15,8 @@ and are converted to JSON according to \code{schema}.}
 \item{loc}{Alternative to \code{txt}. Location where input data is uploaded
 and converted to internal server format.}
 
-\item{schema}{Optional. A JSON string, URL or file that selects the JSON validation
-schema. Only used if the \code{txt} argument is specified.}
+\item{version}{Integer. JSON schema version number. There are currently two
+schemas supported, versions \code{1} and \code{2}.}
 }
 \value{
 A table with screening results

--- a/man/custom_list.Rd
+++ b/man/custom_list.Rd
@@ -4,7 +4,7 @@
 \alias{custom_list}
 \title{Provides a Screen growth curves according to JGZ guidelines}
 \usage{
-custom_list(txt = "", loc = "", version = 1L)
+custom_list(txt = "", loc = "", version = 2L)
 }
 \arguments{
 \item{txt}{A JSON string, URL or file with the data in JSON

--- a/man/draw_chart.Rd
+++ b/man/draw_chart.Rd
@@ -7,7 +7,7 @@
 draw_chart(
   txt = "",
   loc = "",
-  format = 2L,
+  format = "1.0",
   chartcode = "",
   selector = c("data", "derive", "chartcode"),
   chartgrp = NULL,
@@ -42,8 +42,8 @@ and are converted to JSON according to \code{schema}.}
 \item{loc}{Alternative to \code{txt}. Location where input data is uploaded
 and converted to internal server format.}
 
-\item{format}{Integer. JSON schema format number. There are currently two
-schemas supported, formats \code{1} and \code{2}.}
+\item{format}{String. JSON data schema version number. There are currently
+three schemas supported: \code{1.0}, \code{1.1} and \code{2.0}.}
 
 \item{chartcode}{Optional. The code of the requested growth chart.}
 
@@ -133,7 +133,7 @@ The function \code{draw_chart()} plots individual data on the growth chart.
 }
 \examples{
 fn <- system.file("testdata", "client3.json", package = "james")
-g <- draw_chart(txt = fn, format = 1)
+g <- draw_chart(txt = fn)
 }
 \seealso{
 \code{\link[=select_chart]{select_chart()}}

--- a/man/draw_chart.Rd
+++ b/man/draw_chart.Rd
@@ -7,7 +7,7 @@
 draw_chart(
   txt = "",
   loc = "",
-  version = 1L,
+  version = 2L,
   chartcode = "",
   selector = c("data", "derive", "chartcode"),
   chartgrp = NULL,
@@ -133,7 +133,7 @@ The function \code{draw_chart()} plots individual data on the growth chart.
 }
 \examples{
 fn <- system.file("testdata", "client3.json", package = "james")
-g <- draw_chart(txt = fn)
+g <- draw_chart(txt = fn, version = 1)
 }
 \seealso{
 \code{\link[=select_chart]{select_chart()}}

--- a/man/draw_chart.Rd
+++ b/man/draw_chart.Rd
@@ -7,7 +7,7 @@
 draw_chart(
   txt = "",
   loc = "",
-  schema = "bds_schema_str.json",
+  version = 1L,
   chartcode = "",
   selector = c("data", "derive", "chartcode"),
   chartgrp = NULL,
@@ -29,7 +29,8 @@ draw_chart(
   show_future = FALSE,
   draw_grob = TRUE,
   bds_data = "",
-  ind_loc = ""
+  ind_loc = "",
+  ...
 )
 }
 \arguments{
@@ -41,8 +42,8 @@ and are converted to JSON according to \code{schema}.}
 \item{loc}{Alternative to \code{txt}. Location where input data is uploaded
 and converted to internal server format.}
 
-\item{schema}{Optional. A JSON string, URL or file that selects the JSON validation
-schema. Only used if the \code{txt} argument is specified.}
+\item{version}{Integer. JSON schema version number. There are currently two
+schemas supported, versions \code{1} and \code{2}.}
 
 \item{chartcode}{Optional. The code of the requested growth chart.}
 
@@ -121,6 +122,8 @@ Default is \code{TRUE}. For internal use only.}
 \item{bds_data}{Legacy for \code{txt}. Use \code{txt} instead.}
 
 \item{ind_loc}{Legacy for \code{loc}. Use \code{loc} instead.}
+
+\item{...}{Passed down to \code{\link[jsonlite:fromJSON]{jsonlite::fromJSON()}}}
 }
 \value{
 A \code{gTree} object.

--- a/man/draw_chart.Rd
+++ b/man/draw_chart.Rd
@@ -7,7 +7,7 @@
 draw_chart(
   txt = "",
   loc = "",
-  version = 2L,
+  format = 2L,
   chartcode = "",
   selector = c("data", "derive", "chartcode"),
   chartgrp = NULL,
@@ -42,8 +42,8 @@ and are converted to JSON according to \code{schema}.}
 \item{loc}{Alternative to \code{txt}. Location where input data is uploaded
 and converted to internal server format.}
 
-\item{version}{Integer. JSON schema version number. There are currently two
-schemas supported, versions \code{1} and \code{2}.}
+\item{format}{Integer. JSON schema format number. There are currently two
+schemas supported, formats \code{1} and \code{2}.}
 
 \item{chartcode}{Optional. The code of the requested growth chart.}
 
@@ -133,7 +133,7 @@ The function \code{draw_chart()} plots individual data on the growth chart.
 }
 \examples{
 fn <- system.file("testdata", "client3.json", package = "james")
-g <- draw_chart(txt = fn, version = 1)
+g <- draw_chart(txt = fn, format = 1)
 }
 \seealso{
 \code{\link[=select_chart]{select_chart()}}

--- a/man/draw_chart_bds-deprecated.Rd
+++ b/man/draw_chart_bds-deprecated.Rd
@@ -7,7 +7,7 @@
 \usage{
 draw_chart_bds(
   txt = "",
-  format = 2L,
+  format = "1.0",
   chartcode = "",
   curve_interpolation = TRUE,
   selector = "chartcode",
@@ -17,8 +17,8 @@ draw_chart_bds(
 \arguments{
 \item{txt}{A JSON string, URL or file}
 
-\item{format}{Integer. JSON schema format number. There are currently two
-schemas supported, formats \code{1} and \code{2}.}
+\item{format}{String. JSON data schema version number. There are currently
+three schemas supported: \code{1.0}, \code{1.1} and \code{2.0}.}
 
 \item{chartcode}{A string with chart code}
 
@@ -41,6 +41,6 @@ Superseded by \code{\link[=draw_chart]{draw_chart()}}.
 }
 \examples{
 fn <- system.file("testdata", "client3.json", package = "james")
-g <- draw_chart_bds(txt = fn, format = 1)
+g <- draw_chart_bds(txt = fn)
 }
 \keyword{server}

--- a/man/draw_chart_bds-deprecated.Rd
+++ b/man/draw_chart_bds-deprecated.Rd
@@ -7,6 +7,7 @@
 \usage{
 draw_chart_bds(
   txt = "",
+  version = 2L,
   chartcode = "",
   curve_interpolation = TRUE,
   selector = "chartcode",
@@ -15,6 +16,9 @@ draw_chart_bds(
 }
 \arguments{
 \item{txt}{A JSON string, URL or file}
+
+\item{version}{Integer. JSON schema version number. There are currently two
+schemas supported, versions \code{1} and \code{2}.}
 
 \item{chartcode}{A string with chart code}
 
@@ -37,6 +41,6 @@ Superseded by \code{\link[=draw_chart]{draw_chart()}}.
 }
 \examples{
 fn <- system.file("testdata", "client3.json", package = "james")
-g <- draw_chart_bds(txt = fn)
+g <- draw_chart_bds(txt = fn, version = 1)
 }
 \keyword{server}

--- a/man/draw_chart_bds-deprecated.Rd
+++ b/man/draw_chart_bds-deprecated.Rd
@@ -7,7 +7,7 @@
 \usage{
 draw_chart_bds(
   txt = "",
-  version = 2L,
+  format = 2L,
   chartcode = "",
   curve_interpolation = TRUE,
   selector = "chartcode",
@@ -17,8 +17,8 @@ draw_chart_bds(
 \arguments{
 \item{txt}{A JSON string, URL or file}
 
-\item{version}{Integer. JSON schema version number. There are currently two
-schemas supported, versions \code{1} and \code{2}.}
+\item{format}{Integer. JSON schema format number. There are currently two
+schemas supported, formats \code{1} and \code{2}.}
 
 \item{chartcode}{A string with chart code}
 
@@ -41,6 +41,6 @@ Superseded by \code{\link[=draw_chart]{draw_chart()}}.
 }
 \examples{
 fn <- system.file("testdata", "client3.json", package = "james")
-g <- draw_chart_bds(txt = fn, version = 1)
+g <- draw_chart_bds(txt = fn, format = 1)
 }
 \keyword{server}

--- a/man/fetch_loc.Rd
+++ b/man/fetch_loc.Rd
@@ -4,15 +4,13 @@
 \alias{fetch_loc}
 \title{Uploads, parses, converts and stores data on the server for further processing}
 \usage{
-fetch_loc(txt = "", schema = "bds_schema_str.json")
+fetch_loc(txt = "", version = 1L)
 }
 \arguments{
 \item{txt}{A JSON string, URL or file}
 
-\item{schema}{The name of one the the built-in schema's.
-The default (\code{NULL}) loads \code{"bds_schema_str.json"}. See
-\url{https://github.com/growthcharts/bdsreader/tree/master/inst/json}
-for available schema's.}
+\item{version}{Integer. JSON schema version number. There are currently two
+schemas supported, versions \code{1} and \code{2}.}
 }
 \value{
 A tibble with a person attribute

--- a/man/fetch_loc.Rd
+++ b/man/fetch_loc.Rd
@@ -4,13 +4,13 @@
 \alias{fetch_loc}
 \title{Uploads, parses, converts and stores data on the server for further processing}
 \usage{
-fetch_loc(txt = "", version = 2L)
+fetch_loc(txt = "", format = 2L)
 }
 \arguments{
 \item{txt}{A JSON string, URL or file}
 
-\item{version}{Integer. JSON schema version number. There are currently two
-schemas supported, versions \code{1} and \code{2}.}
+\item{format}{Integer. JSON schema format number. There are currently two
+schemas supported, formats \code{1} and \code{2}.}
 }
 \value{
 A tibble with a person attribute
@@ -25,7 +25,7 @@ of the \code{"loc"} argument. The server wipes the cached data after 24 hours.
 }
 \examples{
 fn <- system.file("testdata", "client3.json", package = "james")
-p <- fetch_loc(fn, version = 1)
+p <- fetch_loc(fn, format = 1)
 }
 \seealso{
 \code{\link[bdsreader:read_bds]{bdsreader::read_bds()}}

--- a/man/fetch_loc.Rd
+++ b/man/fetch_loc.Rd
@@ -4,13 +4,13 @@
 \alias{fetch_loc}
 \title{Uploads, parses, converts and stores data on the server for further processing}
 \usage{
-fetch_loc(txt = "", format = 2L)
+fetch_loc(txt = "", format = "1.0")
 }
 \arguments{
 \item{txt}{A JSON string, URL or file}
 
-\item{format}{Integer. JSON schema format number. There are currently two
-schemas supported, formats \code{1} and \code{2}.}
+\item{format}{String. JSON data schema version number. There are currently
+three schemas supported: \code{1.0}, \code{1.1} and \code{2.0}.}
 }
 \value{
 A tibble with a person attribute
@@ -25,7 +25,7 @@ of the \code{"loc"} argument. The server wipes the cached data after 24 hours.
 }
 \examples{
 fn <- system.file("testdata", "client3.json", package = "james")
-p <- fetch_loc(fn, format = 1)
+p <- fetch_loc(fn)
 }
 \seealso{
 \code{\link[bdsreader:read_bds]{bdsreader::read_bds()}}

--- a/man/fetch_loc.Rd
+++ b/man/fetch_loc.Rd
@@ -4,7 +4,7 @@
 \alias{fetch_loc}
 \title{Uploads, parses, converts and stores data on the server for further processing}
 \usage{
-fetch_loc(txt = "", version = 1L)
+fetch_loc(txt = "", version = 2L)
 }
 \arguments{
 \item{txt}{A JSON string, URL or file}
@@ -25,7 +25,7 @@ of the \code{"loc"} argument. The server wipes the cached data after 24 hours.
 }
 \examples{
 fn <- system.file("testdata", "client3.json", package = "james")
-p <- fetch_loc(fn)
+p <- fetch_loc(fn, version = 1)
 }
 \seealso{
 \code{\link[bdsreader:read_bds]{bdsreader::read_bds()}}

--- a/man/request_site.Rd
+++ b/man/request_site.Rd
@@ -4,7 +4,7 @@
 \alias{request_site}
 \title{Request site containing personalised charts}
 \usage{
-request_site(txt = "", loc = "", version = 1L, upload = TRUE, host = NULL)
+request_site(txt = "", loc = "", version = 2L, upload = TRUE, host = NULL)
 }
 \arguments{
 \item{txt}{A JSON string, URL or file with the data in JSON

--- a/man/request_site.Rd
+++ b/man/request_site.Rd
@@ -4,7 +4,7 @@
 \alias{request_site}
 \title{Request site containing personalised charts}
 \usage{
-request_site(txt = "", loc = "", version = 2L, upload = TRUE, host = NULL)
+request_site(txt = "", loc = "", format = 2L, upload = TRUE, host = NULL)
 }
 \arguments{
 \item{txt}{A JSON string, URL or file with the data in JSON
@@ -15,8 +15,8 @@ and are converted to JSON according to \code{schema}.}
 \item{loc}{Alternative to \code{txt}. Location where input data is uploaded
 and converted to internal server format.}
 
-\item{version}{Integer. JSON schema version number. There are currently two
-schemas supported, versions \code{1} and \code{2}.}
+\item{format}{Integer. JSON schema format number. There are currently two
+schemas supported, formats \code{1} and \code{2}.}
 
 \item{upload}{Logical. If \code{TRUE} then \code{request_site()} will upload
 the data in \code{txt} and return a site address with the \verb{?loc=} query appended.

--- a/man/request_site.Rd
+++ b/man/request_site.Rd
@@ -4,13 +4,7 @@
 \alias{request_site}
 \title{Request site containing personalised charts}
 \usage{
-request_site(
-  txt = "",
-  loc = "",
-  schema = "bds_schema_str.json",
-  upload = TRUE,
-  host = NULL
-)
+request_site(txt = "", loc = "", version = 1L, upload = TRUE, host = NULL)
 }
 \arguments{
 \item{txt}{A JSON string, URL or file with the data in JSON
@@ -21,8 +15,8 @@ and are converted to JSON according to \code{schema}.}
 \item{loc}{Alternative to \code{txt}. Location where input data is uploaded
 and converted to internal server format.}
 
-\item{schema}{Optional. A JSON string, URL or file that selects the JSON validation
-schema. Only used if the \code{txt} argument is specified.}
+\item{version}{Integer. JSON schema version number. There are currently two
+schemas supported, versions \code{1} and \code{2}.}
 
 \item{upload}{Logical. If \code{TRUE} then \code{request_site()} will upload
 the data in \code{txt} and return a site address with the \verb{?loc=} query appended.

--- a/man/request_site.Rd
+++ b/man/request_site.Rd
@@ -4,7 +4,7 @@
 \alias{request_site}
 \title{Request site containing personalised charts}
 \usage{
-request_site(txt = "", loc = "", format = 2L, upload = TRUE, host = NULL)
+request_site(txt = "", loc = "", format = "1.0", upload = TRUE, host = NULL)
 }
 \arguments{
 \item{txt}{A JSON string, URL or file with the data in JSON
@@ -15,8 +15,8 @@ and are converted to JSON according to \code{schema}.}
 \item{loc}{Alternative to \code{txt}. Location where input data is uploaded
 and converted to internal server format.}
 
-\item{format}{Integer. JSON schema format number. There are currently two
-schemas supported, formats \code{1} and \code{2}.}
+\item{format}{String. JSON data schema version number. There are currently
+three schemas supported: \code{1.0}, \code{1.1} and \code{2.0}.}
 
 \item{upload}{Logical. If \code{TRUE} then \code{request_site()} will upload
 the data in \code{txt} and return a site address with the \verb{?loc=} query appended.

--- a/man/screen_curves-deprecated.Rd
+++ b/man/screen_curves-deprecated.Rd
@@ -5,7 +5,7 @@
 \alias{screen_curves}
 \title{Screen growth curves according to JGZ guidelines}
 \usage{
-screen_curves(txt = "", loc = "", location = "", version = 1L, legacy = TRUE)
+screen_curves(txt = "", loc = "", location = "", version = 2L, legacy = TRUE)
 }
 \arguments{
 \item{txt}{A JSON string, URL or file with the data in JSON

--- a/man/screen_curves-deprecated.Rd
+++ b/man/screen_curves-deprecated.Rd
@@ -5,13 +5,7 @@
 \alias{screen_curves}
 \title{Screen growth curves according to JGZ guidelines}
 \usage{
-screen_curves(
-  txt = "",
-  loc = "",
-  location = "",
-  schema = "bds_schema_str.json",
-  legacy = TRUE
-)
+screen_curves(txt = "", loc = "", location = "", version = 1L, legacy = TRUE)
 }
 \arguments{
 \item{txt}{A JSON string, URL or file with the data in JSON
@@ -24,8 +18,8 @@ and converted to internal server format.}
 
 \item{location}{Legacy for \code{loc}}
 
-\item{schema}{Optional. A JSON string, URL or file that selects the JSON validation
-schema. Only used if the \code{txt} argument is specified.}
+\item{version}{Integer. JSON schema version number. There are currently two
+schemas supported, versions \code{1} and \code{2}.}
 
 \item{legacy}{Logical indicating whether legacy should be done.}
 }

--- a/man/screen_curves-deprecated.Rd
+++ b/man/screen_curves-deprecated.Rd
@@ -5,7 +5,7 @@
 \alias{screen_curves}
 \title{Screen growth curves according to JGZ guidelines}
 \usage{
-screen_curves(txt = "", loc = "", location = "", version = 2L, legacy = TRUE)
+screen_curves(txt = "", loc = "", location = "", format = 2L, legacy = TRUE)
 }
 \arguments{
 \item{txt}{A JSON string, URL or file with the data in JSON
@@ -18,8 +18,8 @@ and converted to internal server format.}
 
 \item{location}{Legacy for \code{loc}}
 
-\item{version}{Integer. JSON schema version number. There are currently two
-schemas supported, versions \code{1} and \code{2}.}
+\item{format}{Integer. JSON schema format number. There are currently two
+schemas supported, formats \code{1} and \code{2}.}
 
 \item{legacy}{Logical indicating whether legacy should be done.}
 }

--- a/man/screen_curves-deprecated.Rd
+++ b/man/screen_curves-deprecated.Rd
@@ -5,7 +5,7 @@
 \alias{screen_curves}
 \title{Screen growth curves according to JGZ guidelines}
 \usage{
-screen_curves(txt = "", loc = "", location = "", format = 2L, legacy = TRUE)
+screen_curves(txt = "", loc = "", location = "", format = "1.0", legacy = TRUE)
 }
 \arguments{
 \item{txt}{A JSON string, URL or file with the data in JSON
@@ -18,8 +18,8 @@ and converted to internal server format.}
 
 \item{location}{Legacy for \code{loc}}
 
-\item{format}{Integer. JSON schema format number. There are currently two
-schemas supported, formats \code{1} and \code{2}.}
+\item{format}{String. JSON data schema version number. There are currently
+three schemas supported: \code{1.0}, \code{1.1} and \code{2.0}.}
 
 \item{legacy}{Logical indicating whether legacy should be done.}
 }

--- a/man/screen_growth.Rd
+++ b/man/screen_growth.Rd
@@ -4,7 +4,7 @@
 \alias{screen_growth}
 \title{Screen growth curves according to JGZ guidelines}
 \usage{
-screen_growth(txt = "", loc = "", format = 2L)
+screen_growth(txt = "", loc = "", format = "1.0")
 }
 \arguments{
 \item{txt}{A JSON string, URL or file with the data in JSON
@@ -15,8 +15,8 @@ and are converted to JSON according to \code{schema}.}
 \item{loc}{Alternative to \code{txt}. Location where input data is uploaded
 and converted to internal server format.}
 
-\item{format}{Integer. JSON schema format number. There are currently two
-schemas supported, formats \code{1} and \code{2}.}
+\item{format}{String. JSON data schema version number. There are currently
+three schemas supported: \code{1.0}, \code{1.1} and \code{2.0}.}
 }
 \description{
 Screen growth curves according to JGZ guidelines

--- a/man/screen_growth.Rd
+++ b/man/screen_growth.Rd
@@ -4,7 +4,7 @@
 \alias{screen_growth}
 \title{Screen growth curves according to JGZ guidelines}
 \usage{
-screen_growth(txt = "", loc = "", version = 2L)
+screen_growth(txt = "", loc = "", format = 2L)
 }
 \arguments{
 \item{txt}{A JSON string, URL or file with the data in JSON
@@ -15,8 +15,8 @@ and are converted to JSON according to \code{schema}.}
 \item{loc}{Alternative to \code{txt}. Location where input data is uploaded
 and converted to internal server format.}
 
-\item{version}{Integer. JSON schema version number. There are currently two
-schemas supported, versions \code{1} and \code{2}.}
+\item{format}{Integer. JSON schema format number. There are currently two
+schemas supported, formats \code{1} and \code{2}.}
 }
 \description{
 Screen growth curves according to JGZ guidelines

--- a/man/screen_growth.Rd
+++ b/man/screen_growth.Rd
@@ -4,7 +4,7 @@
 \alias{screen_growth}
 \title{Screen growth curves according to JGZ guidelines}
 \usage{
-screen_growth(txt = "", loc = "", version = 1L)
+screen_growth(txt = "", loc = "", version = 2L)
 }
 \arguments{
 \item{txt}{A JSON string, URL or file with the data in JSON

--- a/man/screen_growth.Rd
+++ b/man/screen_growth.Rd
@@ -4,7 +4,7 @@
 \alias{screen_growth}
 \title{Screen growth curves according to JGZ guidelines}
 \usage{
-screen_growth(txt = "", loc = "", schema = "bds_schema_str.json")
+screen_growth(txt = "", loc = "", version = 1L)
 }
 \arguments{
 \item{txt}{A JSON string, URL or file with the data in JSON
@@ -15,8 +15,8 @@ and are converted to JSON according to \code{schema}.}
 \item{loc}{Alternative to \code{txt}. Location where input data is uploaded
 and converted to internal server format.}
 
-\item{schema}{Optional. A JSON string, URL or file that selects the JSON validation
-schema. Only used if the \code{txt} argument is specified.}
+\item{version}{Integer. JSON schema version number. There are currently two
+schemas supported, versions \code{1} and \code{2}.}
 }
 \description{
 Screen growth curves according to JGZ guidelines

--- a/tests/testthat/test-client_server_communication.R
+++ b/tests/testthat/test-client_server_communication.R
@@ -1,9 +1,9 @@
-context("client-server communication")
 library(httr)
 
 # hack to evade ssl verification error: certificate has expired
 # remove hack after server certificate is repaired
 # httr::set_config(config(ssl_verifypeer = 0L))
+host <- "https://groeidiagrammen.nl"
 
 path <- "ocpu/library/james/R/list_charts"
 url <- modify_url(url = host, path = path)
@@ -72,7 +72,7 @@ test_that(
 
 
 # problematic json file not_a_vector.json identified by Allegro Sultum - Feb 2020
-fn <- system.file("extdata", "bds_str", "test", "not_a_vector.json", package = "jamesdemodata")
+fn <- system.file("extdata", "bds_v1.0", "test", "not_a_vector.json", package = "jamesdemodata")
 js <- jsonlite::toJSON(jsonlite::fromJSON(fn), auto_unbox = TRUE)
 
 path <- "ocpu/library/james/R/convert_bds_ind"
@@ -116,7 +116,7 @@ test_that(
 
 
 # problematic json file http400.json identified by Allegro Sultum - Feb 2020
-fn <- system.file("extdata", "bds_str", "test", "http400.json", package = "jamesdemodata")
+fn <- system.file("extdata", "bds_v1.0", "test", "http400.json", package = "jamesdemodata")
 js <- jsonlite::toJSON(jsonlite::fromJSON(fn), auto_unbox = TRUE)
 
 path <- "ocpu/library/james/R/convert_bds_ind"

--- a/tests/testthat/test-request_site.R
+++ b/tests/testthat/test-request_site.R
@@ -7,14 +7,22 @@ kevin <- system.file("testdata", "Kevin_S.json", package = "james")
 kevin_gro <- system.file("testdata", "Kevin_S_gro.json", package = "james")
 kevin_dev <- system.file("testdata", "Kevin_S_dev.json", package = "james")
 
-site_laura <- request_site(laura, host = host)
-site_laura_gro <- request_site(laura_gro, host = host)
-site_laura_dev <- request_site(laura_dev, host = host)
-site_laura_dev_2 <- request_site(laura_dev_2, host = host)
+host <- "https://groeidiagrammen.nl"
 
-site_kevin <- request_site(kevin, host = host)
-site_kevin_gro <- request_site(kevin_gro, host = host)
-site_kevin_dev <- request_site(kevin_dev, host = host)
+test_that(
+  "creates site_laura, with messages",
+  expect_message(site_laura <- request_site(laura, host = host, version = 1))
+)
 
+#site_laura_gro <- request_site(laura_gro, host = host, version = 1)
+#site_laura_dev <- request_site(laura_dev, host = host, version = 1)
+#site_laura_dev_2 <- request_site(laura_dev_2, host = host, version = 1)
 
-# browseURL(site_kevin_dev)
+test_that(
+  "creates site_kevin, with messages",
+  expect_message(site_kevin <- request_site(kevin, host = host, version = 1))
+)
+# site_kevin_gro <- request_site(kevin_gro, host = host, version = 1)
+# site_kevin_dev <- request_site(kevin_dev, host = host, version = 1)
+
+# browseURL(site_laura)

--- a/tests/testthat/test-request_site.R
+++ b/tests/testthat/test-request_site.R
@@ -11,18 +11,18 @@ host <- "https://groeidiagrammen.nl"
 
 test_that(
   "creates site_laura, with messages",
-  expect_message(site_laura <- request_site(laura, host = host, format = 1))
+  expect_message(site_laura <- request_site(laura, host = host))
 )
 
-#site_laura_gro <- request_site(laura_gro, host = host, format = 1)
-#site_laura_dev <- request_site(laura_dev, host = host, format = 1)
-#site_laura_dev_2 <- request_site(laura_dev_2, host = host, format = 1)
+#site_laura_gro <- request_site(laura_gro, host = host)
+#site_laura_dev <- request_site(laura_dev, host = host)
+#site_laura_dev_2 <- request_site(laura_dev_2, host = host)
 
 test_that(
   "creates site_kevin, with messages",
-  expect_message(site_kevin <- request_site(kevin, host = host, format = 1))
+  expect_message(site_kevin <- request_site(kevin, host = host))
 )
-# site_kevin_gro <- request_site(kevin_gro, host = host, format = 1)
-# site_kevin_dev <- request_site(kevin_dev, host = host, format = 1)
+# site_kevin_gro <- request_site(kevin_gro, host = host)
+# site_kevin_dev <- request_site(kevin_dev, host = host)
 
 # browseURL(site_laura)

--- a/tests/testthat/test-request_site.R
+++ b/tests/testthat/test-request_site.R
@@ -11,18 +11,18 @@ host <- "https://groeidiagrammen.nl"
 
 test_that(
   "creates site_laura, with messages",
-  expect_message(site_laura <- request_site(laura, host = host, version = 1))
+  expect_message(site_laura <- request_site(laura, host = host, format = 1))
 )
 
-#site_laura_gro <- request_site(laura_gro, host = host, version = 1)
-#site_laura_dev <- request_site(laura_dev, host = host, version = 1)
-#site_laura_dev_2 <- request_site(laura_dev_2, host = host, version = 1)
+#site_laura_gro <- request_site(laura_gro, host = host, format = 1)
+#site_laura_dev <- request_site(laura_dev, host = host, format = 1)
+#site_laura_dev_2 <- request_site(laura_dev_2, host = host, format = 1)
 
 test_that(
   "creates site_kevin, with messages",
-  expect_message(site_kevin <- request_site(kevin, host = host, version = 1))
+  expect_message(site_kevin <- request_site(kevin, host = host, format = 1))
 )
-# site_kevin_gro <- request_site(kevin_gro, host = host, version = 1)
-# site_kevin_dev <- request_site(kevin_dev, host = host, version = 1)
+# site_kevin_gro <- request_site(kevin_gro, host = host, format = 1)
+# site_kevin_dev <- request_site(kevin_dev, host = host, format = 1)
 
 # browseURL(site_laura)

--- a/tests/testthat/test-screen_curves.R
+++ b/tests/testthat/test-screen_curves.R
@@ -1,11 +1,10 @@
-context("screen_curves")
 library(httr)
-
 library(jamesclient)
 
 # client3.json
 fn <- system.file("extdata", "allegrosultum", "client3.json", package = "jamesdemodata")
 js <- jsonlite::toJSON(jsonlite::fromJSON(fn), auto_unbox = TRUE)
+host <- "https://groeidiagrammen.nl"
 
 path <- "ocpu/library/james/R/fetch_loc"
 url <- modify_url(url = host, path = path)

--- a/tests/testthat/test-screen_growth.R
+++ b/tests/testthat/test-screen_growth.R
@@ -35,7 +35,7 @@ test_that(
 
 # Allegro Sultum 1 sept 2020
 laura_dev <- system.file("testdata", "Laura_S_dev.json", package = "james")
-screen_growth(txt = laura_dev, version = 1)
+screen_growth(txt = laura_dev, format = 1)
 
 laura_dev_2 <- system.file("testdata", "Laura_S_dev_2.json", package = "james")
-screen_growth(txt = laura_dev_2, version = 1)
+screen_growth(txt = laura_dev_2, format = 1)

--- a/tests/testthat/test-screen_growth.R
+++ b/tests/testthat/test-screen_growth.R
@@ -1,4 +1,3 @@
-context("screen_growth")
 library(httr)
 
 library(jamesclient)
@@ -36,7 +35,7 @@ test_that(
 
 # Allegro Sultum 1 sept 2020
 laura_dev <- system.file("testdata", "Laura_S_dev.json", package = "james")
-screen_growth(txt = laura_dev)
+screen_growth(txt = laura_dev, version = 1)
 
 laura_dev_2 <- system.file("testdata", "Laura_S_dev_2.json", package = "james")
-screen_growth(txt = laura_dev_2)
+screen_growth(txt = laura_dev_2, version = 1)

--- a/tests/testthat/test-screen_growth.R
+++ b/tests/testthat/test-screen_growth.R
@@ -35,7 +35,7 @@ test_that(
 
 # Allegro Sultum 1 sept 2020
 laura_dev <- system.file("testdata", "Laura_S_dev.json", package = "james")
-screen_growth(txt = laura_dev, format = 1)
+screen_growth(txt = laura_dev)
 
 laura_dev_2 <- system.file("testdata", "Laura_S_dev_2.json", package = "james")
-screen_growth(txt = laura_dev_2, format = 1)
+screen_growth(txt = laura_dev_2)

--- a/tests/testthat/test-server_side_functions.R
+++ b/tests/testthat/test-server_side_functions.R
@@ -24,7 +24,7 @@ test_that(
 )
 
 # problematic json file not_a_vector.json identified by Allegro Sultum - Feb 2020
-fn <- system.file("extdata", "bds_str", "test", "not_a_vector.json", package = "jamesdemodata")
+fn <- system.file("extdata", "bds_v1.0", "test", "not_a_vector.json", package = "jamesdemodata")
 js <- jsonlite::toJSON(jsonlite::fromJSON(fn), auto_unbox = TRUE)
 
 test_that(
@@ -46,7 +46,7 @@ test_that(
 )
 
 # problematic json file http400.json identified by Allegro Sultum - Feb 2020
-fn <- system.file("extdata", "bds_str", "test", "http400.json", package = "jamesdemodata")
+fn <- system.file("extdata", "bds_v1.0", "test", "http400.json", package = "jamesdemodata")
 js <- jsonlite::toJSON(jsonlite::fromJSON(fn), auto_unbox = TRUE)
 
 test_that(

--- a/tests/testthat/test-server_side_functions.R
+++ b/tests/testthat/test-server_side_functions.R
@@ -4,7 +4,7 @@ js <- jsonlite::toJSON(jsonlite::fromJSON(fn), auto_unbox = TRUE)
 
 test_that(
   "fetch_loc() on client3.json is silent",
-  expect_silent(fetch_loc(js, version = 1))
+  expect_silent(fetch_loc(js, format = 1))
 )
 
 # hack to evade ssl verification error: certificate has expired
@@ -18,7 +18,7 @@ test_that(
 
 test_that(
   "draw_chart() on client3.json is silent",
-  expect_silent(draw_chart(js, version = 1, draw_grob = FALSE, quiet = TRUE))
+  expect_silent(draw_chart(js, format = 1, draw_grob = FALSE, quiet = TRUE))
 )
 
 # problematic json file not_a_vector.json identified by Allegro Sultum - Feb 2020
@@ -27,7 +27,7 @@ js <- jsonlite::toJSON(jsonlite::fromJSON(fn), auto_unbox = TRUE)
 
 test_that(
   "fetch_loc() on not_a_vector.json has messages",
-  expect_message(fetch_loc(js, version = 1))
+  expect_message(fetch_loc(js, format = 1))
 )
 # test_that(
 #   "screen_curves() on not_a_vector.json has messages",
@@ -35,12 +35,12 @@ test_that(
 # )
 test_that(
   "screen_growth() on not_a_vector.json has messages",
-  expect_message(screen_growth(js, version = 1))
+  expect_message(screen_growth(js, format = 1))
 )
 
 test_that(
   "draw_chart() on not_a_vector.json has messages",
-  expect_message(draw_chart(js, version = 1, draw_grob = FALSE))
+  expect_message(draw_chart(js, format = 1, draw_grob = FALSE))
 )
 
 # problematic json file http400.json identified by Allegro Sultum - Feb 2020
@@ -49,7 +49,7 @@ js <- jsonlite::toJSON(jsonlite::fromJSON(fn), auto_unbox = TRUE)
 
 test_that(
   "fetch_loc() on http400.json has messages",
-  expect_silent(fetch_loc(js, version = 1))
+  expect_silent(fetch_loc(js, format = 1))
 )
 # test_that("screen_curves() on http400.json has messages",
 #          expect_silent(y <- screen_curves(js,
@@ -57,5 +57,5 @@ test_that(
 #                                            path = "ocpu/library/james/R/convert_bds_ind")))
 test_that(
   "draw_chart() on http400.json has messages",
-  expect_silent(draw_chart(js, version = 1, quiet = TRUE))
+  expect_silent(draw_chart(js, format = 1, quiet = TRUE))
 )

--- a/tests/testthat/test-server_side_functions.R
+++ b/tests/testthat/test-server_side_functions.R
@@ -4,7 +4,7 @@ js <- jsonlite::toJSON(jsonlite::fromJSON(fn), auto_unbox = TRUE)
 
 test_that(
   "fetch_loc() on client3.json is silent",
-  expect_silent(fetch_loc(js, format = 1))
+  expect_silent(fetch_loc(js))
 )
 
 # hack to evade ssl verification error: certificate has expired
@@ -18,7 +18,7 @@ test_that(
 
 test_that(
   "draw_chart() on client3.json is silent",
-  expect_silent(draw_chart(js, format = 1, draw_grob = FALSE, quiet = TRUE))
+  expect_silent(draw_chart(js, draw_grob = FALSE, quiet = TRUE))
 )
 
 # problematic json file not_a_vector.json identified by Allegro Sultum - Feb 2020
@@ -27,7 +27,7 @@ js <- jsonlite::toJSON(jsonlite::fromJSON(fn), auto_unbox = TRUE)
 
 test_that(
   "fetch_loc() on not_a_vector.json has messages",
-  expect_message(fetch_loc(js, format = 1))
+  expect_message(fetch_loc(js))
 )
 # test_that(
 #   "screen_curves() on not_a_vector.json has messages",
@@ -35,12 +35,12 @@ test_that(
 # )
 test_that(
   "screen_growth() on not_a_vector.json has messages",
-  expect_message(screen_growth(js, format = 1))
+  expect_message(screen_growth(js))
 )
 
 test_that(
   "draw_chart() on not_a_vector.json has messages",
-  expect_message(draw_chart(js, format = 1, draw_grob = FALSE))
+  expect_message(draw_chart(js, draw_grob = FALSE))
 )
 
 # problematic json file http400.json identified by Allegro Sultum - Feb 2020
@@ -49,7 +49,7 @@ js <- jsonlite::toJSON(jsonlite::fromJSON(fn), auto_unbox = TRUE)
 
 test_that(
   "fetch_loc() on http400.json has messages",
-  expect_silent(fetch_loc(js, format = 1))
+  expect_silent(fetch_loc(js))
 )
 # test_that("screen_curves() on http400.json has messages",
 #          expect_silent(y <- screen_curves(js,
@@ -57,5 +57,5 @@ test_that(
 #                                            path = "ocpu/library/james/R/convert_bds_ind")))
 test_that(
   "draw_chart() on http400.json has messages",
-  expect_silent(draw_chart(js, format = 1, quiet = TRUE))
+  expect_silent(draw_chart(js, quiet = TRUE))
 )

--- a/tests/testthat/test-server_side_functions.R
+++ b/tests/testthat/test-server_side_functions.R
@@ -1,12 +1,10 @@
-context("server-side functions")
-
 # client3.json
 fn <- system.file("extdata", "allegrosultum", "client3.json", package = "jamesdemodata")
 js <- jsonlite::toJSON(jsonlite::fromJSON(fn), auto_unbox = TRUE)
 
 test_that(
   "fetch_loc() on client3.json is silent",
-  expect_silent(fetch_loc(js))
+  expect_silent(fetch_loc(js, version = 1))
 )
 
 # hack to evade ssl verification error: certificate has expired
@@ -20,7 +18,7 @@ test_that(
 
 test_that(
   "draw_chart() on client3.json is silent",
-  expect_silent(draw_chart(js, draw_grob = FALSE, quiet = TRUE))
+  expect_silent(draw_chart(js, version = 1, draw_grob = FALSE, quiet = TRUE))
 )
 
 # problematic json file not_a_vector.json identified by Allegro Sultum - Feb 2020
@@ -29,7 +27,7 @@ js <- jsonlite::toJSON(jsonlite::fromJSON(fn), auto_unbox = TRUE)
 
 test_that(
   "fetch_loc() on not_a_vector.json has messages",
-  expect_message(fetch_loc(js))
+  expect_message(fetch_loc(js, version = 1))
 )
 # test_that(
 #   "screen_curves() on not_a_vector.json has messages",
@@ -37,12 +35,12 @@ test_that(
 # )
 test_that(
   "screen_growth() on not_a_vector.json has messages",
-  expect_message(screen_growth(js))
+  expect_message(screen_growth(js, version = 1))
 )
 
 test_that(
   "draw_chart() on not_a_vector.json has messages",
-  expect_message(draw_chart(js, draw_grob = FALSE))
+  expect_message(draw_chart(js, version = 1, draw_grob = FALSE))
 )
 
 # problematic json file http400.json identified by Allegro Sultum - Feb 2020
@@ -51,7 +49,7 @@ js <- jsonlite::toJSON(jsonlite::fromJSON(fn), auto_unbox = TRUE)
 
 test_that(
   "fetch_loc() on http400.json has messages",
-  expect_silent(fetch_loc(js))
+  expect_silent(fetch_loc(js, version = 1))
 )
 # test_that("screen_curves() on http400.json has messages",
 #          expect_silent(y <- screen_curves(js,
@@ -59,5 +57,5 @@ test_that(
 #                                            path = "ocpu/library/james/R/convert_bds_ind")))
 test_that(
   "draw_chart() on http400.json has messages",
-  expect_silent(draw_chart(js, quiet = TRUE))
+  expect_silent(draw_chart(js, version = 1, quiet = TRUE))
 )


### PR DESCRIPTION
This PR changes introduces the `format` argument as simpler alternative to the `schema` specification. The PR deprecates `schema`.

Merge only after the swagger has been updated and when clients are aware of the change.