### PR TITLE
Specify absolute paths so site doesn't break after rewrite

### DIFF
--- a/inst/www/index.html
+++ b/inst/www/index.html
@@ -5,15 +5,15 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="shortcut icon" href="#" />
-  <link rel="stylesheet" href="css/bootstrap.min.css">
-  <link rel="stylesheet" href="css/ion.rangeSlider.min.css">
-  <link rel="stylesheet" href="main.css">
-  <script type="text/javascript" src="js/jquery-3.5.1.min.js"></script>
-  <script type="text/javascript" src="js/popper.min.js"></script>
-  <script type="text/javascript" src="js/bootstrap.min.js"></script>
-  <script type="text/javascript" src="js/ion.rangeSlider.min.js"></script>
-  <script type="text/javascript" src="opencpu-0.5-james-0.1.js"></script>
-  <script type="text/javascript" src="update.js"></script>
+  <link rel="stylesheet" href="/ocpu/lib/james/www/css/bootstrap.min.css">
+  <link rel="stylesheet" href="/ocpu/lib/james/www/css/ion.rangeSlider.min.css">
+  <link rel="stylesheet" href="/ocpu/lib/james/www/main.css">
+  <script type="text/javascript" src="/ocpu/lib/james/www/js/jquery-3.5.1.min.js"></script>
+  <script type="text/javascript" src="/ocpu/lib/james/www/js/popper.min.js"></script>
+  <script type="text/javascript" src="/ocpu/lib/james/www/js/bootstrap.min.js"></script>
+  <script type="text/javascript" src="/ocpu/lib/james/www/js/ion.rangeSlider.min.js"></script>
+  <script type="text/javascript" src="/ocpu/lib/james/www/opencpu-0.5-james-0.1.js"></script>
+  <script type="text/javascript" src="/ocpu/lib/james/www/update.js"></script>
 </head>
 
 <body>
@@ -242,6 +242,6 @@
       </div>
     </div>
   </div> <!-- end container-fluid -->
-  <script type="text/javascript" src="start.js"></script>
+  <script type="text/javascript" src="/ocpu/lib/james/www/start.js"></script>
 </body>
 </html>

--- a/inst/www/start.js
+++ b/inst/www/start.js
@@ -9,6 +9,8 @@ var user_loc = urlParams.get('loc');
 if (urlParams.has('ind')) user_loc = urlParams.get('ind');
 const user_chartcode = urlParams.get('chartcode');
 
+ocpu.seturl("/ocpu/library/james/R"); //hardcode path
+
 
 // internal constants
 const slider_values = {


### PR DESCRIPTION
Use longer paths in javascript to support to support Apace rewrites