### PR TITLE
Throttle 3 seconds and event attachment in JS

### DIFF
--- a/inst/www/index.html
+++ b/inst/www/index.html
@@ -47,7 +47,7 @@
           <div class="card" id = "groeicard">
             <div class="card-header">
               <a class="card-link" data-toggle="collapse" href="#collapseOne" id = "groei">
-                <strong onclick="toggleDisplay('plotDiv', 'textDiv')">Groei</strong>
+                <strong>Groei</strong>
               </a>
             </div>
             <div id="collapseOne" class="collapse show" data-parent="#accordion">
@@ -108,7 +108,7 @@
                 <p id="chartcode"></p>
                 <br>
 
-                <input type="checkbox" id="interpolation" checked='true' onchange="update()">
+                <input type="checkbox" id="interpolation" checked='true'>
                 Curve interpolation<br>
               </div>
             </div>
@@ -118,7 +118,7 @@
           <div class="card" id = "ontwikkelingcard">
             <div class="card-header">
               <a class="card-link" data-toggle="collapse" href="#collapseTwo" id = "ontwikkeling">
-                <strong onclick="toggleDisplay('plotDiv', 'textDiv')">Ontwikkeling</strong>
+                <strong>Ontwikkeling</strong>
               </a>
             </div>
             <div id="collapseTwo" class="collapse" data-parent="#accordion">
@@ -148,7 +148,7 @@
                 <p id="chartcode_dsc"></p>
                 <br>
 
-                <input type="checkbox" id="interpolation_dsc" checked='true' onchange="update()">
+                <input type="checkbox" id="interpolation_dsc" checked='true'>
                 Curve interpolation<br>
 
               </div>
@@ -158,7 +158,7 @@
           <div class="card">
             <div class="card-header">
               <a class="collapsed card-link" data-toggle="collapse" href="#collapseThree" id = "voorspeller">
-              <strong onclick="toggleDisplay('plotDiv','textDiv')">Voorspeller</strong>
+              <strong>Voorspeller</strong>
             </a>
             </div>
             <div id="collapseThree" class="collapse" data-parent="#accordion">
@@ -190,7 +190,7 @@
                 <div class="form-group">
                   <div class="checkbox">
                     <label>
-                      <input id="exact_sex" type="checkbox" checked="checked" onchange="update()"/>
+                      <input id="exact_sex" type="checkbox" checked="checked"/>
                       <span>Zelfde geslacht</span>
                     </label>
                   </div>
@@ -199,7 +199,7 @@
                 <div class="form-group" style="display:none;">
                   <div class="checkbox">
                     <label>
-                      <input id="exact_ga" type="checkbox" onchange="update()"/>
+                      <input id="exact_ga" type="checkbox">
                       <span>Zelfde zwangerschapsduur</span>
                     </label>
                   </div>
@@ -208,7 +208,7 @@
                 <div class="form-group">
                   <div class="checkbox">
                     <label>
-                      <input id="show_future" type="checkbox" onchange="update()"/>
+                      <input id="show_future" type="checkbox"/>
                       <span>Kijk in toekomst</span>
                     </label>
                   </div>
@@ -217,7 +217,7 @@
                 <div class="form-group">
                   <div class="checkbox">
                     <label>
-                      <input id="show_realized" type="checkbox" onchange="update()"/>
+                      <input id="show_realized" type="checkbox"/>
                       <span>Gerealiseerde groei</span>
                     </label>
                   </div>
@@ -231,7 +231,7 @@
           <div class="card">
             <div class="card-header">
               <a class="card-link" data-toggle="collapse" href="#collapseFour" id = "meldingen">
-                <strong onclick="toggleDisplay('textDiv', 'plotDiv')">Meldingen</strong>
+                <strong>Meldingen</strong>
               </a>
             </div>
             <div id="collapseFour" class="collapse" data-parent="#accordion">

--- a/inst/www/js/handleUIVisibility.js
+++ b/inst/www/js/handleUIVisibility.js
@@ -1,3 +1,9 @@
+// handleUIvisibility.js
+// Author: Stef van Buuren
+// (c) 2024 Netherlands Organisation for Applied Scientific Research TNO, Leiden
+// Part of the JAMES package
+// Licence: AGPL
+
 function handleUIVisibility(chartgrp, agegrp, population) {
   if (chartgrp == 'nl2010') {
     sr('agegrp_1-21y', 'block');

--- a/inst/www/js/opencpu-0.5-james-0.1.js
+++ b/inst/www/js/opencpu-0.5-james-0.1.js
@@ -2,7 +2,7 @@
  * File: opencpu-0.5-james-x.y.js
  * Javascript client library for OpenCPU
  * Version 0.5.0
- * -- Adapted for JAMES by Stef van Buuren --- May 2019
+ * -- Adapted for JAMES by Stef van Buuren
  * Depends: jQuery
  * Requires HTML5 FormData support for file uploads
  * http://github.com/jeroenooms/opencpu.js

--- a/inst/www/js/start.js
+++ b/inst/www/js/start.js
@@ -1,4 +1,8 @@
 // start.js
+// Author: Stef van Buuren
+// (c) 2024 Netherlands Organisation for Applied Scientific Research TNO, Leiden
+// Part of the JAMES package
+// Licence: AGPL
 
 // Constants for OpenCPU server configuration based on environment
 const isSingleUser = false;
@@ -15,11 +19,7 @@ const userChartcode = urlParams.get('chartcode') || '';
 // Set the OpenCPU server URL
 ocpu.seturl(isSingleUser ? "../R" : `//${hostname}${basePath}/ocpu/library/james/R`);
 
-// Slider values configuration
-
-
 // Defaults
-let sliderList = "0_2";
 let chartcode = "NJAH";
 $("#donordata").val("0-2");
 
@@ -91,7 +91,7 @@ function initializeSlider(selector, options) {
   $(selector).ionRangeSlider($.extend({}, commonOptions, options));
 }
 
-// Slider values, assuming sliderValues and sliderList are defined elsewhere
+// Slider values
 const sliderValues = {
   "0_2": ["0w", "4w", "8w", "3m", "4m", "6m", "7.5m", "9m", "11m", "14m", "18m", "24m"],
   "0_4": ["0w", "4w", "8w", "3m", "4m", "6m", "7.5m", "9m", "11m", "14m", "18m", "24m", "36m", "45m"],
@@ -99,6 +99,7 @@ const sliderValues = {
   "0_29": ["0w", "3m", "6m", "14m", "24m", "48m", "10y", "18y"],
   "matches": ["0", "1", "2", "5", "10", "25", "50", "100"]
 };
+let sliderList = "0_2";
 
 // Initialize the sliders with both common and specific options
 initializeSlider("#weekslider", { min: 25, max: 36, from: 36, step: 1 });

--- a/inst/www/js/start.js
+++ b/inst/www/js/start.js
@@ -16,65 +16,12 @@ const userChartcode = urlParams.get('chartcode') || '';
 ocpu.seturl(isSingleUser ? "../R" : `//${hostname}${basePath}/ocpu/library/james/R`);
 
 // Slider values configuration
-const sliderValues = {
-  "0_2": ["0w", "4w", "8w", "3m", "4m", "6m", "7.5m", "9m", "11m", "14m", "18m", "24m"],
-  "0_4": ["0w", "4w", "8w", "3m", "4m", "6m", "7.5m", "9m", "11m", "14m", "18m", "24m", "36m", "45m"],
-  "0_19": ["0w", "3m", "6m", "12m", "24m", "5y", "9y", "10y", "11y", "14y", "19y"],
-  "0_29": ["0w", "3m", "6m", "14m", "24m", "48m", "10y", "18y"],
-  "matches": ["0", "1", "2", "5", "10", "25", "50", "100"]
-};
+
 
 // Defaults
 let sliderList = "0_2";
 let chartcode = "NJAH";
 $("#donordata").val("0-2");
-
-// Fire up sliders
-$("#weekslider").ionRangeSlider({
-  type: "single",
-  skin: "round",
-  grid_snap: true,
-  min: 25,
-  max: 36,
-  from: 36,
-  step: 1,
-  onFinish: function (data) {
-            throttledUpdate();
-  }
-});
-$("#matchslider").ionRangeSlider({
-  type: "single",
-  skin: "round",
-  grid_snap: true,
-  from: 0,
-  values: sliderValues[["matches"]],
-  onFinish: function (data) {
-            throttledUpdate();
-  }
-});
-$("#visitslider").ionRangeSlider({
-  type: "double",
-  skin: "round",
-  grid_snap: true,
-  min_interval: 0,
-  drag_interval: true,
-  values: sliderValues[[sliderList]],
-  onFinish: function (data) {
-            throttledUpdate();
-  }
-});
-$("#weekslider_dsc").ionRangeSlider({
-  type: "single",
-  skin: "round",
-  grid_snap: true,
-  min: 25,
-  max: 36,
-  from: 36,
-  step: 1,
-  onFinish: function (data) {
-            throttledUpdate();
-  }
-});
 
 // Event attachment for UI controls
 const addChangeListenerUpdate = (elementId) => {
@@ -130,6 +77,34 @@ document.addEventListener('DOMContentLoaded', function() {
     }
   });
 });
+
+// Event attachment for UI controls: sliders
+function initializeSlider(selector, options) {
+  const commonOptions = {
+    type: "single",
+    skin: "round",
+    grid_snap: true,
+    onFinish: throttledUpdate
+  };
+
+  // Merge common options with specific options provided for each slider
+  $(selector).ionRangeSlider($.extend({}, commonOptions, options));
+}
+
+// Slider values, assuming sliderValues and sliderList are defined elsewhere
+const sliderValues = {
+  "0_2": ["0w", "4w", "8w", "3m", "4m", "6m", "7.5m", "9m", "11m", "14m", "18m", "24m"],
+  "0_4": ["0w", "4w", "8w", "3m", "4m", "6m", "7.5m", "9m", "11m", "14m", "18m", "24m", "36m", "45m"],
+  "0_19": ["0w", "3m", "6m", "12m", "24m", "5y", "9y", "10y", "11y", "14y", "19y"],
+  "0_29": ["0w", "3m", "6m", "14m", "24m", "48m", "10y", "18y"],
+  "matches": ["0", "1", "2", "5", "10", "25", "50", "100"]
+};
+
+// Initialize the sliders with both common and specific options
+initializeSlider("#weekslider", { min: 25, max: 36, from: 36, step: 1 });
+initializeSlider("#matchslider", { from: 0, values: sliderValues["matches"] });
+initializeSlider("#visitslider", { type: "double", min_interval: 0, drag_interval: true, values: sliderValues[sliderList] });
+initializeSlider("#weekslider_dsc", { min: 25, max: 36, from: 36, step: 1 });
 
 // Set active accordion page
 let active = "groei";

--- a/inst/www/js/start.js
+++ b/inst/www/js/start.js
@@ -105,13 +105,13 @@ addChangeListenerUpdate('chartgrp');
 addChangeListenerUpdate('chartgrp_dsc');
 
 // Event attachment for check boxes
-addChangeListenerThrottledUpdateUpdate('interpolation');
-addChangeListenerThrottledUpdateUpdate('interpolation_dsc');
-addChangeListenerThrottledUpdateUpdate('exact_sex');
-addChangeListenerThrottledUpdateUpdate('exact_ga');
-addChangeListenerThrottledUpdateUpdate('show_future');
-addChangeListenerThrottledUpdateUpdate('show_realized');
-addChangeListenerThrottledUpdateUpdate('exact_ga');
+addChangeListenerThrottledUpdate('interpolation');
+addChangeListenerThrottledUpdate('interpolation_dsc');
+addChangeListenerThrottledUpdate('exact_sex');
+addChangeListenerThrottledUpdate('exact_ga');
+addChangeListenerThrottledUpdate('show_future');
+addChangeListenerThrottledUpdate('show_realized');
+addChangeListenerThrottledUpdate('exact_ga');
 
 // Event attachment for radio buttons
 ["agegrp", "msr", "etnicity", "sex", "agegrp_dsc"].forEach(formName => {

--- a/inst/www/js/start.js
+++ b/inst/www/js/start.js
@@ -76,7 +76,62 @@ $("#weekslider_dsc").ionRangeSlider({
   }
 });
 
-// set active accordion page
+// Event attachment for UI controls
+const addChangeListenerUpdate = (elementId) => {
+  document.getElementById(elementId).addEventListener('change', update, false);
+};
+const addChangeListenerThrottledUpdate = (elementId) => {
+  document.getElementById(elementId).addEventListener('change', throttledUpdate, false);
+};
+
+// Event attachment for UI controls: menus
+addChangeListenerUpdate('chartgrp');
+addChangeListenerUpdate('chartgrp_dsc');
+
+// Event attachment for UI controls: check boxes
+addChangeListenerThrottledUpdate('interpolation');
+addChangeListenerThrottledUpdate('interpolation_dsc');
+addChangeListenerThrottledUpdate('exact_sex');
+addChangeListenerThrottledUpdate('exact_ga');
+addChangeListenerThrottledUpdate('show_future');
+addChangeListenerThrottledUpdate('show_realized');
+addChangeListenerThrottledUpdate('exact_ga');
+
+// Event attachment for UI controls: radio buttons
+["agegrp", "msr", "etnicity", "sex", "agegrp_dsc"].forEach(formName => {
+  const radios = document.forms[formName].elements[formName];
+  for (let radio of radios) {
+    radio.onclick = throttledUpdate;
+  }
+});
+
+// Event attachment for UI controls: accordion
+document.addEventListener('DOMContentLoaded', function() {
+  // Create a mapping of element IDs to the function arguments they correspond to.
+  // This assumes toggleDisplay accepts two arguments for divs to show/hide.
+  const linksToToggle = {
+    'groei': ['plotDiv', 'textDiv'],
+    'ontwikkeling': ['plotDiv', 'textDiv'],
+    'voorspeller': ['plotDiv', 'textDiv'],
+    'meldingen': ['textDiv', 'plotDiv']
+  };
+
+  // Iterate over the entries in the mapping object.
+  Object.entries(linksToToggle).forEach(([id, divs]) => {
+    const link = document.getElementById(id);
+    if (link) { // Check if the element exists to avoid null reference errors
+      link.addEventListener('click', function(event) {
+        // Prevent the default action if it's a link or a button inside a form
+        event.preventDefault();
+
+        // Call toggleDisplay with the div IDs specific to this link
+        toggleDisplay(...divs);
+      });
+    }
+  });
+});
+
+// Set active accordion page
 let active = "groei";
 $('#groei').click(function (){
         if (active != "groei"){
@@ -91,60 +146,6 @@ $('#ontwikkeling').click(function (){
           update();
         }
     });
-
-// Listeners for UI controls
-const addChangeListenerUpdate = (elementId) => {
-  document.getElementById(elementId).addEventListener('change', update, false);
-};
-const addChangeListenerThrottledUpdate = (elementId) => {
-  document.getElementById(elementId).addEventListener('change', throttledUpdate, false);
-};
-
-// Event attachment for menus
-addChangeListenerUpdate('chartgrp');
-addChangeListenerUpdate('chartgrp_dsc');
-
-// Event attachment for check boxes
-addChangeListenerThrottledUpdate('interpolation');
-addChangeListenerThrottledUpdate('interpolation_dsc');
-addChangeListenerThrottledUpdate('exact_sex');
-addChangeListenerThrottledUpdate('exact_ga');
-addChangeListenerThrottledUpdate('show_future');
-addChangeListenerThrottledUpdate('show_realized');
-addChangeListenerThrottledUpdate('exact_ga');
-
-// Event attachment for radio buttons
-["agegrp", "msr", "etnicity", "sex", "agegrp_dsc"].forEach(formName => {
-  const radios = document.forms[formName].elements[formName];
-  for (let radio of radios) {
-    radio.onclick = throttledUpdate;
-  }
-});
-
-document.addEventListener('DOMContentLoaded', function() {
-  var link = document.getElementById('groei');
-  link.addEventListener('click', function(event) {
-    toggleDisplay('plotDiv', 'textDiv');
-  });
-});
-document.addEventListener('DOMContentLoaded', function() {
-  var link = document.getElementById('ontwikkeling');
-  link.addEventListener('click', function(event) {
-    toggleDisplay('plotDiv', 'textDiv');
-  });
-});
-document.addEventListener('DOMContentLoaded', function() {
-  var link = document.getElementById('voorspeller');
-  link.addEventListener('click', function(event) {
-    toggleDisplay('plotDiv', 'textDiv');
-  });
-});
-document.addEventListener('DOMContentLoaded', function() {
-  var link = document.getElementById('meldingen');
-  link.addEventListener('click', function(event) {
-    toggleDisplay('textDiv', 'plotDiv');
-  });
-});
 
 // Selector logic
 let selector = userChartcode ? "chartcode" : (userText || userSession) ? "data" : "derive";

--- a/inst/www/js/start.js
+++ b/inst/www/js/start.js
@@ -39,7 +39,7 @@ $("#weekslider").ionRangeSlider({
   from: 36,
   step: 1,
   onFinish: function (data) {
-            update();
+            throttledUpdate();
   }
 });
 $("#matchslider").ionRangeSlider({
@@ -49,7 +49,7 @@ $("#matchslider").ionRangeSlider({
   from: 0,
   values: sliderValues[["matches"]],
   onFinish: function (data) {
-            update();
+            throttledUpdate();
   }
 });
 $("#visitslider").ionRangeSlider({
@@ -60,7 +60,7 @@ $("#visitslider").ionRangeSlider({
   drag_interval: true,
   values: sliderValues[[sliderList]],
   onFinish: function (data) {
-            update();
+            throttledUpdate();
   }
 });
 $("#weekslider_dsc").ionRangeSlider({
@@ -72,7 +72,7 @@ $("#weekslider_dsc").ionRangeSlider({
   from: 36,
   step: 1,
   onFinish: function (data) {
-            update();
+            throttledUpdate();
   }
 });
 
@@ -93,12 +93,25 @@ $('#ontwikkeling').click(function (){
     });
 
 // Listeners for UI controls
-const addChangeListener = (elementId) => {
+const addChangeListenerUpdate = (elementId) => {
   document.getElementById(elementId).addEventListener('change', update, false);
 };
+const addChangeListenerThrottledUpdate = (elementId) => {
+  document.getElementById(elementId).addEventListener('change', throttledUpdate, false);
+};
 
-addChangeListener('chartgrp');
-addChangeListener('chartgrp_dsc');
+// Event attachment for menus
+addChangeListenerUpdate('chartgrp');
+addChangeListenerUpdate('chartgrp_dsc');
+
+// Event attachment for check boxes
+addChangeListenerThrottledUpdateUpdate('interpolation');
+addChangeListenerThrottledUpdateUpdate('interpolation_dsc');
+addChangeListenerThrottledUpdateUpdate('exact_sex');
+addChangeListenerThrottledUpdateUpdate('exact_ga');
+addChangeListenerThrottledUpdateUpdate('show_future');
+addChangeListenerThrottledUpdateUpdate('show_realized');
+addChangeListenerThrottledUpdateUpdate('exact_ga');
 
 // Event attachment for radio buttons
 ["agegrp", "msr", "etnicity", "sex", "agegrp_dsc"].forEach(formName => {
@@ -106,6 +119,31 @@ addChangeListener('chartgrp_dsc');
   for (let radio of radios) {
     radio.onclick = throttledUpdate;
   }
+});
+
+document.addEventListener('DOMContentLoaded', function() {
+  var link = document.getElementById('groei');
+  link.addEventListener('click', function(event) {
+    toggleDisplay('plotDiv', 'textDiv');
+  });
+});
+document.addEventListener('DOMContentLoaded', function() {
+  var link = document.getElementById('ontwikkeling');
+  link.addEventListener('click', function(event) {
+    toggleDisplay('plotDiv', 'textDiv');
+  });
+});
+document.addEventListener('DOMContentLoaded', function() {
+  var link = document.getElementById('voorspeller');
+  link.addEventListener('click', function(event) {
+    toggleDisplay('plotDiv', 'textDiv');
+  });
+});
+document.addEventListener('DOMContentLoaded', function() {
+  var link = document.getElementById('meldingen');
+  link.addEventListener('click', function(event) {
+    toggleDisplay('textDiv', 'plotDiv');
+  });
 });
 
 // Selector logic

--- a/inst/www/js/start.js
+++ b/inst/www/js/start.js
@@ -104,7 +104,7 @@ addChangeListener('chartgrp_dsc');
 ["agegrp", "msr", "etnicity", "sex", "agegrp_dsc"].forEach(formName => {
   const radios = document.forms[formName].elements[formName];
   for (let radio of radios) {
-    radio.onclick = update;
+    radio.onclick = throttledUpdate;
   }
 });
 

--- a/inst/www/js/update.js
+++ b/inst/www/js/update.js
@@ -118,5 +118,5 @@ function drawChart(params) {
   });
 }
 
-// Create a throttled version of update that can only be called once every 1000 milliseconds (1 second)
-const throttledUpdate = throttle(update, 1000);
+// Create a throttled version of update that can only be called once every 5000 milliseconds (5 seconds)
+const throttledUpdate = throttle(update, 5000);

--- a/inst/www/js/update.js
+++ b/inst/www/js/update.js
@@ -67,6 +67,42 @@ function update() {
   });
 }
 
+/**
+ * Creates a throttled version of a function that only invokes the original
+ * function at most once per every wait milliseconds.
+ *
+ * @param {Function} func The function to throttle.
+ * @param {number} wait The number of milliseconds to throttle invocations to.
+ * @return {Function} A throttled version of the function.
+ */
+function throttle(func, wait) {
+  let isThrottling = false;
+  let lastArgs;
+  let lastThis;
+
+  const invokeFunc = () => {
+    isThrottling = true;
+    setTimeout(() => {
+      isThrottling = false;
+      if (lastArgs) {
+        invokeFunc.apply(lastThis, lastArgs);
+        lastArgs = lastThis = null;
+      }
+    }, wait);
+
+    func.apply(lastThis, lastArgs);
+  };
+
+  return function() {
+    if (!isThrottling) {
+      invokeFunc.apply(this, arguments);
+    } else {
+      lastArgs = arguments;
+      lastThis = this;
+    }
+  };
+}
+
 function drawChart(params) {
   const rq = $("#plotDiv").rplot("draw_chart", params, session => {
     updateNoticePanel(2, session);
@@ -81,3 +117,6 @@ function drawChart(params) {
     // Logging or user notification
   });
 }
+
+// Create a throttled version of update that can only be called once every 1000 milliseconds (1 second)
+const throttledUpdate = throttle(update, 1000);

--- a/inst/www/js/update.js
+++ b/inst/www/js/update.js
@@ -118,5 +118,5 @@ function drawChart(params) {
   });
 }
 
-// Create a throttled version of update that can only be called once every 5000 milliseconds (5 seconds)
-const throttledUpdate = throttle(update, 5000);
+// Set throttleUpdate to 3 seconds
+const throttledUpdate = throttle(update, 3000);

--- a/inst/www/js/update.js
+++ b/inst/www/js/update.js
@@ -1,6 +1,8 @@
 // update.js
-// Author: Stef van Buuren, 2019-2023
-// Netherlands Organisation for Applied Scientific Research TNO, Leiden
+// Author: Stef van Buuren
+// (c) 2024 Netherlands Organisation for Applied Scientific Research TNO, Leiden
+// Part of the JAMES package
+// Licence: AGPL
 
 function update() {
   // Use let for variables that may change within the function


### PR DESCRIPTION
This PR introduces a throttling of 3 seconds for radio buttons, sliders and checkboxes. When a user clicks an element, JAMES will immediatetly send a request to the OCPU server, and then pause for 3 seconds before sending a next request. This reduces the strain on the server by users that are just "randomly clicking". 

This PR also moves event attachment code from `index.html` to `start.js` to separate static UI definitions from its dynamic behaviour.