### PR TITLE
Version update 2.12

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: james
 Type: Package
 Title: Joint Automatic Measurement and Evaluation System
-Version: 1.11.1
+Version: 1.11.2
 Authors@R: c(person("Stef", "van Buuren", email = "stef.vanbuuren@tno.nl", role = c("cre", "aut")), 
              person("Arjan", "Huizing", email = "arjan.huizing@tno.nl", role = "aut"),
              person("Iris", "Eekhout", email = "iris.eekhout@tno.nl", role = "aut"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: james
 Type: Package
 Title: Joint Automatic Measurement and Evaluation System
-Version: 1.11.2
+Version: 1.12
 Authors@R: c(person("Stef", "van Buuren", email = "stef.vanbuuren@tno.nl", role = c("cre", "aut")), 
              person("Arjan", "Huizing", email = "arjan.huizing@tno.nl", role = "aut"),
              person("Iris", "Eekhout", email = "iris.eekhout@tno.nl", role = "aut"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# james 1.11.2 (March 2026)
+# james 1.12 (March 2026)
 
 - add domain balancing options to `dcat()`, new arguments: `domain_set` and `k_domain`.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# james 1.12 (March 2026)
+# james 1.12 (April 2026)
 
 - add domain balancing options to `dcat()`, new arguments: `domain_set` and `k_domain`.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# james 1.11.2 (March 2026)
+
+- add domain balancing options to `dcat()`, new arguments: `domain_set` and `k_domain`.
+
 # james 1.11.1 (Februari 2026)
 
 - Add new argument `min_length` to `dcat()`

--- a/R/dcat.R
+++ b/R/dcat.R
@@ -12,6 +12,9 @@
 #' @inheritParams request_site
 #' @param sem_rule numeric target for sem can be estimated based on Cohen's d
 #' from `sem_rule()`.
+#' @param domain_set String. The name of the set of domains to use. See with(builtin_domaintable, table(set, domain)) for the domain names in each set.
+#' @param k_domain integer. Minimum target for the number of items in each
+#' domain, default is set to `k_domain = 0`.
 #'
 #' @return A string with an item name or a table.
 #' @author Iris Eekhout 2025
@@ -29,6 +32,8 @@ dcat <- function(
   p = 50,
   min_length = 0,
   sem_rule = 1.726,
+  domain_set = "GFCLS",
+  k_domain = 0,
   session = "",
   format = "3.1",
   ...
@@ -81,7 +86,9 @@ dcat <- function(
     p = p,
     min_length = min_length,
     instrument = instrument,
-    sem_rule = sem_rule
+    sem_rule = sem_rule,
+    domain_set = domain_set,
+    k_domain = k_domain
   )
 
   return(dcat_result)

--- a/james.Rproj
+++ b/james.Rproj
@@ -1,5 +1,4 @@
 Version: 1.0
-ProjectId: 17171aa3-cbd2-4b18-a321-318927b0cb93
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/man/dcat.Rd
+++ b/man/dcat.Rd
@@ -13,6 +13,8 @@ dcat(
   p = 50,
   min_length = 0,
   sem_rule = 1.726,
+  domain_set = "GFCLS",
+  k_domain = 0,
   session = "",
   format = "3.1",
   ...
@@ -39,6 +41,11 @@ default is set to \code{min_length = 0}.}
 
 \item{sem_rule}{numeric target for sem can be estimated based on Cohen's d
 from \code{sem_rule()}.}
+
+\item{domain_set}{String. The name of the set of domains to use. See with(builtin_domaintable, table(set, domain)) for the domain names in each set.}
+
+\item{k_domain}{integer. Minimum target for the number of items in each
+domain, default is set to \code{k_domain = 0}.}
 
 \item{session}{Optional session key if data is already uploaded to \code{sitehost}.}
 


### PR DESCRIPTION
- update to version 2.12
- add domain balancing options to `dcat()`, new arguments: `domain_set` and `k_domain`.
